### PR TITLE
Separating out local and ldap login flows

### DIFF
--- a/components/login/LoginForm.vue
+++ b/components/login/LoginForm.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from "@headlessui/vue";
+import LoginFailed from "./LoginFailed.vue";
+
+const props = defineProps({
+  authMethod: {
+    type: String,
+    required: true,
+    validator(val) {
+      return ["Local", "LDAP"].includes(val);
+    },
+  },
+});
+
+const open = ref(false);
+
+const userInput = ref({
+  username: "",
+  passwordField: "",
+  agree: false,
+});
+
+const dialogOpen = ref(false);
+
+const isAuthenticated = useCookie("is-authenticated");
+const currentUser = useCookie("current-user");
+
+const router = useRouter();
+
+async function loginUser() {
+  console.log("Starting Login: ", props.authMethod);
+  console.log(userInput.value.username.toLowerCase());
+  if (
+    userInput.value.username.length > 0 &&
+    userInput.value.passwordField.length > 0 &&
+    userInput.value.agree === true
+  ) {
+    console.log("Login: Fields filled");
+    try {
+      console.log("Calling login api");
+      let apiError = null;
+
+      if (props.authMethod === "Local") {
+        const { error } = await useFetch("/api/auth/login/local", {
+          method: "POST",
+          body: {
+            email: userInput.value.username.toLowerCase(),
+            password: userInput.value.passwordField,
+          },
+        });
+        apiError = error;
+      } else if (props.authMethod === "LDAP") {
+        const { error } = await useFetch("/api/auth/login/ldap", {
+          method: "POST",
+          body: {
+            username: userInput.value.username.toLowerCase(),
+            password: userInput.value.passwordField,
+          },
+        });
+        apiError = error;
+      } else {
+        throw createError({ statusCode: 500, statusMessage: "Unsupported authentication method" });
+      }
+
+      if (apiError && apiError.value) {
+        console.log("Login error:", apiError);
+        dialogOpen.value = true;
+      } else {
+        console.log("Login successful");
+
+        isAuthenticated.value = "true";
+        currentUser.value = userInput.value.username;
+
+        router.push("/home");
+      }
+    } catch (error) {
+      console.log("Login error caught:", error);
+    }
+  }
+};
+</script>
+
+<template>
+  <form class="space-y-6" @submit.prevent>
+    <div>
+      <label for="username" class="block text-sm font-medium leading-6 text-gray-800 dark:text-white"> Username </label>
+      <div class="mt-2">
+        <input
+          id="text"
+          v-model="userInput.username"
+          name="text"
+          type="text"
+          autocomplete="text"
+          required
+          class="block w-full rounded-md border-0 bg-white py-1.5 text-black shadow-sm ring-1 ring-inset ring-black/20 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:bg-white/5 dark:text-white dark:ring-white/10 sm:text-sm sm:leading-6"
+        />
+      </div>
+    </div>
+
+    <div>
+      <div class="flex items-center justify-between">
+        <label for="password" class="block text-sm font-medium leading-6 text-gray-800 dark:text-white">Password</label>
+      </div>
+      <div class="mt-2">
+        <input
+          id="password"
+          v-model="userInput.passwordField"
+          name="password"
+          type="password"
+          autocomplete="current-password"
+          required
+          class="block w-full rounded-md border-0 bg-white py-1.5 text-black shadow-sm ring-1 ring-inset ring-black/20 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:bg-white/5 dark:text-white dark:ring-white/10 sm:text-sm sm:leading-6"
+        />
+      </div>
+    </div>
+    <fieldset>
+      <div class="space-y-5">
+        <div class="relative flex items-start">
+          <div class="flex h-6 items-center">
+            <input
+              id="comments"
+              v-model="userInput.agree"
+              aria-describedby="comments-description"
+              required
+              name="comments"
+              type="checkbox"
+              class="h-4 w-4 cursor-pointer rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+            />
+          </div>
+          <div class="ml-3 text-sm leading-6">
+            <label for="comments" class="font-medium text-gray-500">
+              I agree to the terms of the
+              <a
+                class="cursor-pointer font-semibold leading-6 text-indigo-400 hover:text-indigo-300"
+                @click="open = true"
+                >IS User Agreement</a
+              >
+            </label>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+    <!-- Consent Banner --->
+    <TransitionRoot as="template" :show="open">
+      <Dialog as="div" class="relative z-10" @close="open = false">
+        <TransitionChild
+          as="template"
+          enter="ease-out duration-300"
+          enter-from="opacity-0"
+          enter-to="opacity-100"
+          leave="ease-in duration-200"
+          leave-from="opacity-100"
+          leave-to="opacity-0"
+        >
+          <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </TransitionChild>
+        <div class="fixed inset-0 z-10 overflow-y-auto">
+          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <TransitionChild
+              as="template"
+              enter="ease-out duration-300"
+              enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enter-to="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leave-from="opacity-100 translate-y-0 sm:scale-100"
+              leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <DialogPanel
+                class="relative transform overflow-hidden rounded-lg bg-gray-100 px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-gray-900 sm:my-8 sm:w-full sm:max-w-xl sm:p-6"
+              >
+                <div>
+                  <div class="text-center">
+                    <DialogTitle as="h3" class="text-base font-semibold leading-6 text-black dark:text-white"
+                      >Consent To Monitor
+                    </DialogTitle>
+                    <div class="mt-2">
+                      <p class="text-sm text-gray-600 dark:text-white">
+                        You are accessing a U.S. Government (USG) Information System (IS) that is provided for
+                        USG-authorized use only. By using this IS (which includes any device attached to this IS), you
+                        consent to the following conditions:
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <!-- Sign In Button -->
+                <div class="mt-5 sm:mt-6">
+                  <button
+                    type="button"
+                    class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    @click="open = false"
+                  >
+                    Go back to login
+                  </button>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </Dialog>
+    </TransitionRoot>
+    <div>
+      <button
+        type="submit"
+        class="flex w-full justify-center rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        @click="loginUser"
+      >
+        Sign in
+      </button>
+      <Footer />
+    </div>
+    <LoginFailed :show="dialogOpen" :dialog-open="dialogOpen" @change="dialogOpen = false" />
+  </form>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,6 @@ export default defineNuxtConfig({
     temp_folder: process.env.TEMP_FOLDER || "./tmp",
     jwt_key: process.env.JWT_KEY,
     usesqlite: process.env.SQLITE,
-    ldap_enabled: process.env.LDAP_ENABLED || 'false',
     ldap_host: process.env.LDAP_HOST,
     ldap_port: process.env.LDAP_PORT || '389',
     ldap_binddn: process.env.LDAP_BINDDN,
@@ -28,7 +27,10 @@ export default defineNuxtConfig({
     ldap_mailfield: process.env.LDAP_MAILFIELD || 'mail',
     ldap_ssl: process.env.LDAP_SSL || 'false',
     ldap_ssl_insecure: process.env.LDAP_SSL_INSECURE || 'false',
-    ldap_ssl_ca: process.env.LDAP_SSL_CA
+    ldap_ssl_ca: process.env.LDAP_SSL_CA,
+    public: {
+      ldap_enabled: process.env.LDAP_ENABLED || 'false',
+    },
   },
   telemetry: false,
   alias: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,62 +1,31 @@
 <script setup>
-import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from "@headlessui/vue";
-import LoginFailed from "../components/login/LoginFailed.vue";
+import { ref, watch } from "vue";
+import LoginForm from "../components/login/LoginForm.vue";
+
+const config = useRuntimeConfig();
+const ldapEnabled = config.public.ldap_enabled === 'true';
 
 definePageMeta({
   layout: false,
 });
 
-const isAuthenticated = useCookie("is-authenticated");
-const currentUser = useCookie("current-user");
-
-const router = useRouter();
-
-const userInput = ref({
-  username: "",
-  passwordField: "",
-  agree: false,
-});
-
-const dialogOpen = ref(false);
-
-const loginUser = async () => {
-  console.log("Starting Login");
-  console.log(userInput.value.username.toLowerCase());
-  if (
-    userInput.value.username.length > 0 &&
-    userInput.value.passwordField.length > 0 &&
-    userInput.value.agree === true
-  ) {
-    console.log("Login: Fields filled");
-    try {
-      console.log("Calling login api");
-      const { error: apiError } = await useFetch("/api/auth/login", {
-        method: "POST",
-        body: {
-          email: userInput.value.username.toLowerCase(),
-          password: userInput.value.passwordField,
-        },
-      });
-
-      if (apiError && apiError.value) {
-        console.log("Login error:", apiError);
-        dialogOpen.value = true;
-      } else {
-        console.log("Login successful");
-
-        isAuthenticated.value = "true";
-        currentUser.value = userInput.value.username;
-
-        router.push("/home");
+const authMethods = ref([
+  { name: "Local", current: !ldapEnabled},
+  ...(ldapEnabled ? [{ name: "LDAP", current: ldapEnabled }] : []),
+]);
+const selectedAuthMethod = ref(authMethods.value.find((method) => method.current).name);
+watch(selectedAuthMethod, (newMethod, oldMethod) => {
+      const methodToDeselect = authMethods.value.find((method) => method.name === oldMethod);
+      if (methodToDeselect) {
+        methodToDeselect.current = false;
       }
-    } catch (error) {
-      console.log("Login error caught:", error);
-    }
-  }
-};
-
-const open = ref(false);
+      const methodToSelect = authMethods.value.find((method) => method.name === newMethod);
+      if (methodToSelect) {
+        methodToSelect.current = true;
+      }
+});
 </script>
+
 <template>
   <div class="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">
@@ -68,141 +37,42 @@ const open = ref(false);
         Sign in to your account
       </h4>
     </div>
-
     <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-      <form class="space-y-6" @submit.prevent>
-        <div>
-          <label for="username" class="block text-sm font-medium leading-6 text-gray-800 dark:text-white">
-            Username
-          </label>
-          <div class="mt-2">
-            <input
-              id="text"
-              v-model="userInput.username"
-              name="text"
-              type="text"
-              autocomplete="text"
-              required
-              class="block w-full rounded-md border-0 bg-white py-1.5 text-black shadow-sm ring-1 ring-inset ring-black/20 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:bg-white/5 dark:text-white dark:ring-white/10 sm:text-sm sm:leading-6"
-            />
-          </div>
-        </div>
-
-        <div>
-          <div class="flex items-center justify-between">
-            <label for="password" class="block text-sm font-medium leading-6 text-gray-800 dark:text-white"
-              >Password</label
-            >
-          </div>
-          <div class="mt-2">
-            <input
-              id="password"
-              v-model="userInput.passwordField"
-              name="password"
-              type="password"
-              autocomplete="current-password"
-              required
-              class="block w-full rounded-md border-0 bg-white py-1.5 text-black shadow-sm ring-1 ring-inset ring-black/20 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:bg-white/5 dark:text-white dark:ring-white/10 sm:text-sm sm:leading-6"
-            />
-          </div>
-        </div>
-        <fieldset>
-          <div class="space-y-5">
-            <div class="relative flex items-start">
-              <div class="flex h-6 items-center">
-                <input
-                  id="comments"
-                  v-model="userInput.agree"
-                  aria-describedby="comments-description"
-                  required
-                  name="comments"
-                  type="checkbox"
-                  class="h-4 w-4 cursor-pointer rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                />
-              </div>
-              <div class="ml-3 text-sm leading-6">
-                <label for="comments" class="font-medium text-gray-500">
-                  I agree to the terms of the
-                  <a
-                    class="cursor-pointer font-semibold leading-6 text-indigo-400 hover:text-indigo-300"
-                    @click="open = true"
-                    >IS User Agreement</a
-                  >
-                </label>
-              </div>
-            </div>
-          </div>
-        </fieldset>
-        <!-- Consent Banner --->
-        <TransitionRoot as="template" :show="open">
-          <Dialog as="div" class="relative z-10" @close="open = false">
-            <TransitionChild
-              as="template"
-              enter="ease-out duration-300"
-              enter-from="opacity-0"
-              enter-to="opacity-100"
-              leave="ease-in duration-200"
-              leave-from="opacity-100"
-              leave-to="opacity-0"
-            >
-              <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
-            </TransitionChild>
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-              <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-                <TransitionChild
-                  as="template"
-                  enter="ease-out duration-300"
-                  enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                  enter-to="opacity-100 translate-y-0 sm:scale-100"
-                  leave="ease-in duration-200"
-                  leave-from="opacity-100 translate-y-0 sm:scale-100"
-                  leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                >
-                  <DialogPanel
-                    class="relative transform overflow-hidden rounded-lg bg-gray-100 px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-gray-900 sm:my-8 sm:w-full sm:max-w-xl sm:p-6"
-                  >
-                    <div>
-                      <div class="text-center">
-                        <DialogTitle as="h3" class="text-base font-semibold leading-6 text-black dark:text-white"
-                          >Consent To Monitor
-                        </DialogTitle>
-                        <div class="mt-2">
-                          <p class="text-sm text-gray-600 dark:text-white">
-                            You are accessing a U.S. Government (USG) Information System (IS) that is provided for
-                            USG-authorized use only. By using this IS (which includes any device attached to this IS),
-                            you consent to the following conditions:
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                    <!-- Sign In Button -->
-                    <div class="mt-5 sm:mt-6">
-                      <button
-                        type="button"
-                        class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                        @click="open = false"
-                      >
-                        Go back to login
-                      </button>
-                    </div>
-                  </DialogPanel>
-                </TransitionChild>
-              </div>
-            </div>
-          </Dialog>
-        </TransitionRoot>
-        <div>
-          <button
-            type="submit"
-            class="flex w-full justify-center rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-            @click="loginUser"
+      <div>
+        <div class="sm:hidden">
+          <label for="authMethods" class="sr-only">Select an authentication method</label>
+          <select
+            id="authMethods"
+            v-model="selectedAuthMethod"
+            name="authMethods"
+            class="block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
           >
-            Sign in
-          </button>
-          <Footer />
+            <option v-for="authMethod in authMethods" :key="authMethod.name" :value="authMethod.name">
+              {{ authMethod.name }}
+            </option>
+          </select>
         </div>
-        <LoginFailed :show="dialogOpen" :dialog-open="dialogOpen" @change="dialogOpen = false" />
-      </form>
+        <div class="hidden sm:block">
+          <div class="border-b border-gray-200">
+            <nav class="-mb-px flex space-x-8" aria-label="Authentication Methods">
+              <div
+                v-for="authMethod in authMethods"
+                :key="authMethod.name"
+                :class="[
+                  authMethod.current
+                    ? 'border-indigo-500 text-indigo-600'
+                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                  'whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium',
+                ]"
+                @click="selectedAuthMethod = authMethod.name"
+              >
+                {{ authMethod.name }}
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+      <LoginForm :auth-method="selectedAuthMethod"/>
     </div>
   </div>
 </template>

--- a/server/api/auth/login/ldap.post.ts
+++ b/server/api/auth/login/ldap.post.ts
@@ -9,13 +9,15 @@ if (!config.jwt_key) {
   throw new Error("jwt_key is not set.");
 }
 
+const ldapEnabled = config.public.ldap_enabled === "true" || config.public.ldap_enabled === true;
+const ldapSSL = config.ldap_ssl_insecure === "true" || config.ldap_ssl_insecure === true;
+
 const SECRET_KEY = config.jwt_key as string;
 
 function getSSLConfig(): false | { rejectUnauthorized: boolean; ca: string | Buffer } {
   if (config.ldap_ssl !== "true") {
     return false;
   }
-
   let sslCA: string | Buffer | undefined = config.ldap_ssl_ca;
   if (!sslCA) {
     throw new Error("SSL CA file or path to file not provided");
@@ -32,21 +34,22 @@ function getSSLConfig(): false | { rejectUnauthorized: boolean; ca: string | Buf
   }
 
   return {
-    rejectUnauthorized: config.ldap_ssl_insecure !== "true",
+    rejectUnauthorized: !config.ldap_ssl_insecure,
     ca: sslCA,
   };
 }
 
 export default defineEventHandler(async (event) => {
-    console.log("entering ldap flow");
+  console.log("entering ldap flow");
   const body = await readBody(event);
   const username = body.username;
   const password = body.password;
 
   let propagatedError = null;
-  let user: User | null = null;
+  // let user: User | null = null;
+  let userFound = false;
 
-  let inLDAPCallbacks = config.public.ldap_enabled === "true";
+  let inLDAPCallbacks = ldapEnabled;
   const inLDAPCallbacksPromise = new Promise<void>((resolve) => {
     const intervalTimeout = setInterval(() => {
       if (!inLDAPCallbacks) {
@@ -60,13 +63,21 @@ export default defineEventHandler(async (event) => {
   });
   console.log(`initial state of inldapcallbacks: ${inLDAPCallbacks}`);
 
-  if (config.public.ldap_enabled === "true") {
-    console.log('entering ldap enabled flow');
+  let userPromiseResolve: (value: User | PromiseLike<User> | null) => void;
+  const userPromise = new Promise<User | null>((resolve) => {
+    userPromiseResolve = resolve;
+  });
+
+  if (ldapEnabled) {
+    console.log("entering ldap enabled flow");
     let sslConfig;
-    try{
-    sslConfig = getSSLConfig();
+    try {
+      sslConfig = getSSLConfig();
     } catch (e) {
-      propagatedError ??= createError({statusCode: 500, statusMessage: e instanceof Error ? e.message : `LDAP SSL configuration failed: ${e}`});
+      propagatedError ??= createError({
+        statusCode: 500,
+        statusMessage: e instanceof Error ? e.message : `LDAP SSL configuration failed: ${e}`,
+      });
       inLDAPCallbacks = false;
     }
     console.log("created sslconfig");
@@ -82,14 +93,20 @@ export default defineEventHandler(async (event) => {
     console.log("attempted to create clients");
 
     searchClient.on("error", (err) => {
-      propagatedError ??= createError({statusCode: 500, statusMessage: err instanceof Error ? err.message : `Search client errored out: ${err}`});
+      propagatedError ??= createError({
+        statusCode: 500,
+        statusMessage: err instanceof Error ? err.message : `Search client errored out: ${err}`,
+      });
       searchClient.unbind();
       userClient.unbind();
       console.log(`Search client errored out: ${err}`);
       inLDAPCallbacks = false;
     });
     userClient.on("error", (err) => {
-      propagatedError ??= createError({statusCode: 500, statusMessage: err instanceof Error ? err.message : `User client errored out: ${err}`});
+      propagatedError ??= createError({
+        statusCode: 500,
+        statusMessage: err instanceof Error ? err.message : `User client errored out: ${err}`,
+      });
       searchClient.unbind();
       userClient.unbind();
       console.log(`User client errored out: ${err}`);
@@ -110,7 +127,10 @@ export default defineEventHandler(async (event) => {
 
       searchClient.bind(config.ldap_binddn, config.ldap_password, (err) => {
         if (err) {
-          propagatedError ??= createError({statusCode: 500, statusMessage: err instanceof Error ? err.message : `Search client bind failed: ${err}`});
+          propagatedError ??= createError({
+            statusCode: 500,
+            statusMessage: err instanceof Error ? err.message : `Search client bind failed: ${err}`,
+          });
           searchClient.unbind();
           userClient.unbind();
           console.log(`Search client bind err: ${err}`);
@@ -122,24 +142,27 @@ export default defineEventHandler(async (event) => {
           (err, res) => {
             console.log("Attempted to do a search");
             if (err) {
-          propagatedError ??= createError({statusCode: 500, statusMessage: err instanceof Error ? err.message : `Search client search failed: ${err}`});
-          searchClient.unbind();
-          userClient.unbind();
-          console.log(`Search client bind err: ${err}`);
+              propagatedError ??= createError({
+                statusCode: 500,
+                statusMessage:
+                  err instanceof Error ? err.message : `Search client search failed: ${err}`,
+              });
+              searchClient.unbind();
+              userClient.unbind();
+              console.log(`Search client bind err: ${err}`);
             }
+            console.log(`res on search: ${res}`);
 
             res.on("searchEntry", (entry) => {
+              userFound = true;
               console.log("entry: " + entry.pojo);
               console.log("entry bindproperty: " + entry.dn);
               console.log("entry id: " + entry.id);
 
-              console.log("entry.dn.tostring typeof: " + typeof entry.dn.toString());
-              console.log("typeof password: " + typeof password);
-              // console.log("password: " + password);
-
-              client2.bind(entry.dn.toString(), password, async (err) => {
+              userClient.bind(entry.dn.toString(), password, async (err) => {
                 console.log("in interior bind");
                 if (err) {
+                  userPromiseResolve(null);
                   console.log(`LDAP user password validation err: ${err}`);
                   // should be valid to throw an error here for the try ldap -> local auth here so that we can say that found an ldap user but they got the password wrong
                   throw createError({
@@ -152,8 +175,9 @@ export default defineEventHandler(async (event) => {
                 const userEmail = entry.attributes.find(
                   (attr) => attr.type === config.ldap_mailfield,
                 )?.values[0]; // assuming that everyone has at least one email but should probs throw an error if this assumption is false
+
                 console.log(`useremail: ${userEmail}`);
-                user = await User.findOne({ where: { email: userEmail } });
+                const user = await User.findOne({ where: { email: userEmail } });
                 console.log(`user exists? ${user}`);
                 if (!user) {
                   console.log("entered user creation process");
@@ -167,28 +191,35 @@ export default defineEventHandler(async (event) => {
                     UserRoleId: 2, // normal user - should replace this with api call probably?
                     TimezoneName: "America/New_York",
                   };
-                  user = await $fetch("/api/users/create", { method: "POST", body: userData });
+                  const user: User | null = await $fetch("/api/users/create", {
+                    method: "POST",
+                    body: userData,
+                  });
                   console.log("attempted to create user");
-                  if (!user) {
+                  if (user) {
+                    userPromiseResolve(user);
+                  } else {
                     console.log("failed at creating user");
                     throw createError({
                       statusCode: 401,
                       statusMessage: "Couldn't create TIR user based off of LDAP user",
                     });
                   }
+                } else {
+                  userPromiseResolve(user);
                 }
               });
             });
             res.on("error", (err) => {
               console.error("error: " + err.message);
               // presumably handle this error
-              client.unbind((err) => {
+              searchClient.unbind((err) => {
                 if (err) {
                   console.log(`LDAP server unbind err: ${err}`);
                   // throw createError({statusCode: 401, statusMessage: `LDAP server unbind err: ${err}`});
                 }
               });
-              client2.unbind((err) => {
+              userClient.unbind((err) => {
                 if (err) {
                   console.log(`LDAP server unbind err: ${err}`);
                   // throw createError({statusCode: 401, statusMessage: `LDAP server unbind err: ${err}`});
@@ -197,14 +228,23 @@ export default defineEventHandler(async (event) => {
             });
             res.on("end", (result) => {
               // will need to add logic here for if we end without having found any search results
+              // doesnt' seem to be a way to get that information from result.
               console.log("status: " + result?.status);
-              client.unbind((err) => {
+              console.log(`result: ${result}`);
+              if (!userFound) {
+                logger.info({
+                  service: "auth",
+                  message: `Non-existing ldap user login attempt.  Username: ${username}`,
+                });
+                userPromiseResolve(null);
+              }
+              searchClient.unbind((err) => {
                 if (err) {
                   console.log(`LDAP server unbind err: ${err}`);
                   // throw createError({statusCode: 401, statusMessage: `LDAP server unbind err: ${err}`});
                 }
               });
-              client2.unbind((err) => {
+              userClient.unbind((err) => {
                 if (err) {
                   console.log(`LDAP server unbind err: ${err}`);
                   // throw createError({statusCode: 401, statusMessage: `LDAP server unbind err: ${err}`});
@@ -219,16 +259,19 @@ export default defineEventHandler(async (event) => {
 
   await inLDAPCallbacksPromise;
 
-  if(propagatedError !== null) {
-    throw propagatedError;
+  const user = await userPromise;
+
+  if (!user) {
+    if (user === null) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: "Invalid Username or Password",
+      });
+    }
   }
 
-  if (user === null) {
-    console.log("no user found");
-    throw createError({
-      statusCode: 401,
-      statusMessage: "Login Failed",
-    });
+  if (propagatedError !== null) {
+    throw propagatedError;
   }
 
   const cookieName = "tirtoken";
@@ -244,6 +287,5 @@ export default defineEventHandler(async (event) => {
     token: jwt.sign({ userId: user.id }, SECRET_KEY, { expiresIn: "2h" }),
     userId: user.id,
   };
-
   return results;
 });

--- a/server/api/auth/login/ldap.post.ts
+++ b/server/api/auth/login/ldap.post.ts
@@ -46,7 +46,6 @@ export default defineEventHandler(async (event) => {
   const password = body.password;
 
   let propagatedError = null;
-  // let user: User | null = null;
   let userFound = false;
 
   let inLDAPCallbacks = ldapEnabled;

--- a/server/api/auth/login/ldap.post.ts
+++ b/server/api/auth/login/ldap.post.ts
@@ -34,13 +34,13 @@ function getSSLConfig(): false | { rejectUnauthorized: boolean; ca: string | Buf
   }
 
   return {
-    rejectUnauthorized: !config.ldap_ssl_insecure,
+    rejectUnauthorized: !ldapSSL,
     ca: sslCA,
   };
 }
 
 export default defineEventHandler(async (event) => {
-  console.log("entering ldap flow");
+  logger.debug({ service: "auth", message: `entering ldap flow` });
   const body = await readBody(event);
   const username = body.username;
   const password = body.password;
@@ -53,15 +53,18 @@ export default defineEventHandler(async (event) => {
   const inLDAPCallbacksPromise = new Promise<void>((resolve) => {
     const intervalTimeout = setInterval(() => {
       if (!inLDAPCallbacks) {
-        console.log("Out of ldap callbacks");
+        logger.debug({ service: "auth", message: `Out of ldap callbacks` });
         clearInterval(intervalTimeout);
         resolve();
       } else {
-        console.log("Still in ldap callbacks");
+        logger.debug({ service: "auth", message: `Still in ldap callbacks` });
       }
     }, 1000);
   });
-  console.log(`initial state of inldapcallbacks: ${inLDAPCallbacks}`);
+  logger.debug({
+    service: "auth",
+    message: `initial state of inldapcallbacks: ${inLDAPCallbacks}`,
+  });
 
   let userPromiseResolve: (value: User | PromiseLike<User> | null) => void;
   const userPromise = new Promise<User | null>((resolve) => {
@@ -69,7 +72,7 @@ export default defineEventHandler(async (event) => {
   });
 
   if (ldapEnabled) {
-    console.log("entering ldap enabled flow");
+    logger.debug({ service: "auth", message: `entering ldap enabled flow` });
     let sslConfig;
     try {
       sslConfig = getSSLConfig();

--- a/server/api/auth/login/local.post.ts
+++ b/server/api/auth/login/local.post.ts
@@ -1,0 +1,53 @@
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import { User } from "../../../../db/models";
+
+const config = useRuntimeConfig();
+
+if (!config.jwt_key) {
+  throw new Error("jwt_key is not set.");
+}
+
+const SECRET_KEY = config.jwt_key as string;
+
+export default defineEventHandler(async (event) => {
+  console.log("entered local flow");
+  const body = await readBody(event);
+  const email = body.email;
+  const password = body.password;
+
+  console.log("entered local flow");
+  const user = await User.findOne({ where: { email } });
+  if (!user) {
+    console.log("couldn't find user");
+    throw createError({
+      statusCode: 401,
+      statusMessage: "Unknown User",
+    });
+  }
+
+  const validPassword = await bcrypt.compare(password, user.password);
+  if (!validPassword) {
+    console.log("invalid password");
+    throw createError({
+      statusCode: 401,
+      statusMessage: "Bad Password",
+    });
+  }
+
+  const cookieName = "tirtoken";
+  setCookie(event, cookieName, jwt.sign({ userId: user.id }, SECRET_KEY, { expiresIn: "2h" }), {
+    httpOnly: true,
+    path: "/",
+    sameSite: "strict",
+    secure: false, // process.env.NODE_ENV === "production",
+    // expires: new Date(Date.now() + '2h'),
+  });
+
+  const results = {
+    token: jwt.sign({ userId: user.id }, SECRET_KEY, { expiresIn: "2h" }),
+    userId: user.id,
+  };
+
+  return results;
+});


### PR DESCRIPTION
This is further work done based off of #7.  The intent was to simplify the logic for the login api call by completely separating out the logic for the local auth from the ldap auth.  This is definitely still WIP but outlines the approach I wanted to take.  The original flow basically tried to do the ldap approach and then silently fail if that didn't work into the local flow.  If that still failed, then the user was given the invalid login modal.  The new flow is based off of 1) the user choosing which auth flow they want via tab, and 2) then the tabs changing the prop passed into the loginform (separated out into a component from where it was embedded within the page originally), which then 3) let's the form determine which api function to call.

Once I separated the auth flows, I made the local auth back to what it had originally been doing more or less.  Work still remains on fixing up the ldap flow.  Callbacks / event based programming makes it hard to deal with race conditions.  The flow in #7 had a race condition where the connection to the ldap server occasionally closed before we were finished extracting all of the information we needed to do the auth.  

I've run out of time, but I was going through and trying to more rigorously handle the callback stuff so that we would properly process errors and not have any race conditions.  The key thing left is processing all the search entries probably by putting them into a data structure of some kind, and only choosing to do the user client bind -> tir user lookup/creation inside the res.on("end") callback.  This'll also make it easier to determine if we run into an erroneous state (i.e. 2+ search entries means the provided ldap_searchfilter field didn't actually have unique results), the user doesn't exist on the ldap server, or if we discovered the one and only user which we then should try to log in.

Useful links:

https://github.com/mitre/heimdall2/wiki/Environment-Variables-Configuration - explanation/use for all the ldap variables (straight copy paste from heimdall, but i put all the default values in the nuxt.config instead of at runtime like heimdall does)

https://github.com/rroemhild/docker-test-openldap/tree/master - the test ldap server that Heimdall uses in its own testing.  I think it might be possible to make it work with LDAPS but didn't have the time to figure it out so I only tested it with normal LDAP.

https://github.com/mitre/heimdall2/blob/master/apps/backend/src/authn/ldap.strategy.ts - LDAP passport strategy we use in Heimdall.  Passport doesn't seem to have an integration with nuxt3 as of yet.  In fact, nuxt3 doesn't seem to have an official auth solution they support yet (https://auth.nuxtjs.org/) - they recommend some community libraries, but the first doesn't seem to support LDAP and the second looked like it was going to take a while to figure out how to make work with LDAP.  We might want to transition to that one in the future as our replacement for Passport if the official auth doesn't come about soon / have a passport integration.

https://github.com/mitre/heimdall2/blob/6fd5fabbb052499aa10a372b3e66e9a3c4f0f93b/.github/workflows/e2e-ui-tests.yml - example of the docker-test-openldap lib being used.  I want us to set up github CI similar to this so that we can start testing stuff.  Ideally we try using Playwright instead of Cypress though.

http://ldapjs.org/client.html - ldapjs docs

https://github.com/ldapjs/node-ldapjs/tree/master - ldapjs repo

https://github.com/vesse/passport-ldapauth/blob/master/lib/passport-ldapauth/strategy.js - the logic for how the ldapjs passport strategy works.  They use a wrapper library around ldapjs but the wrapper library doesn't seem to be maintained, and is using an old major version of ldapjs.

https://github.com/vesse/node-ldapauth-fork/blob/master/lib/ldapauth.js - the wrapper library, specifically all the code for dealing with ldapjs

https://tailwindui.com/components/application-ui/navigation/tabs - modified the tailwindui tabs component to change the variables around so that it would change the prop as opposed to navigate to a different page