### PR TITLE
chore(issue-templates): adopt native issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Something is broken
-title: "[Bug] "
-labels: ["type:bug", "needs-triage"]
+type: Bug
+labels: ["needs-triage"]
 body:
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,7 +1,7 @@
 name: 🔧 Chore
 description: Internal work, refactor, or maintenance
-title: "[Chore] "
-labels: ["type:chore"]
+type: Task
+labels: ["chore"]
 body:
   - type: textarea
     id: goal

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,7 +1,7 @@
 name: 📚 Documentation
 description: Missing, wrong, or unclear docs
-title: "[Docs] "
-labels: ["type:docs"]
+type: Task
+labels: ["documentation"]
 body:
   - type: input
     id: location

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature Request
 description: Propose new functionality
-title: "[Feature] "
-labels: ["type:feature", "needs-discussion"]
+type: Feature
+labels: ["needs-discussion"]
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
Switches the issue templates to GitHub's native issue types and removes the duplicated category encoding.

- `bug.yml` -> type: Bug
- `feature.yml` -> type: Feature
- `chore.yml` -> type: Task + `chore` label
- `doc.yml` -> type: Task + `documentation` label

Title prefixes and `type:*` labels removed; workflow labels (`needs-triage`, `needs-discussion`) retained.

### Question for an org admin

mitre currently exposes only the default native types (Bug / Feature / Task), so `chore` and `doc` both map to Task and are distinguished here by the `chore` / `documentation` labels. For what it's worth, I also didn't notice any other mitre repos using the native Types yet.

@aaronlippold - no urgency on this, but is customizing the org-level issue types something that's on the table at mitre? If there's any chance of a couple more types being set up down the line, we could simplify these templates further. Ideally adding a `chore` and `docs` type. The label approach works fine in the meantime, so mostly just flagging it to see what makes sense. cc @Amndeep7

Leaving this PR open for now in case the direction changes.
