### PR TITLE
docs(adr): propose multi-identity login and user-merge design

### DIFF
--- a/docs/adr/0001-multi-identity-login.md
+++ b/docs/adr/0001-multi-identity-login.md
@@ -1,0 +1,94 @@
+---
+status: proposed
+date: 2026-06-03
+decision-makers: Mark Rivera, Amndeep Singh Mann
+consulted: Aaron Lippold
+---
+
+# Users authenticate through Identities, not a single email key
+
+## Context and Problem Statement
+
+Every provider resolves the login to a User by email:
+`User.findOne({ where: { email } })` in local, LDAP, and OIDC. Email is the
+implicit link between a person and their account. That has two consequences. If
+two providers happen to carry the same email, they collapse onto the same User
+by coincidence of the address, not by any deliberate link. If they carry
+different emails, each provider lands on (or creates) a separate User, and there
+is no way to tell TIR those accounts are the same person. So a person cannot
+deliberately link identities that do not share an email, and the separate
+accounts that result cannot be merged. MITRE raised multi-identity logins and
+account-merge as a nice-to-have (see #171, #170, and the PR #183 review). How
+should a User relate to the credentials they log in with?
+
+## Decision Drivers
+
+- Linking a person's logins should be explicit, not an accident of matching
+  email addresses.
+- A person should be reachable by any of their credentials (local, LDAP, OIDC,
+  OAuth) even when the emails differ.
+- Account-merge is only coherent if a User can hold more than one Identity.
+- The email-as-login-key assumption is baked into every provider; new user,
+  auth, and member features pay to work around it.
+- Credential storage should be consolidated, not spread across User columns.
+
+## Considered Options
+
+- Keep email as the login key: no Identity table, one account per
+  email per provider.
+- Multi-valued Identity model: move credentials and external keys onto a
+  one-to-many Identity table.
+
+## Decision Outcome
+
+Chosen option: "Multi-valued Identity model", because the single-identity
+assumption is a structural constraint that the user, auth, and member areas keep
+paying for, and fixing the foundation once is cheaper than continuing to build
+around it.
+
+A User may hold several login Identities. Credentials and external keys (email /
+OIDC subject / LDAP DN, and the local password credential) move off the User row
+onto a one-to-many Identity table. Login resolves
+`provider + external key -> Identity -> User`, replacing today's
+`User.findOne({ where: { email } })`. The User keeps a single `primaryEmail` for
+display and notifications.
+
+### Consequences
+
+- Good, because account-merge (ADR 0002) becomes possible and one person can log
+  in through any provider and land on the same User even when the emails differ.
+- Good, because credential storage is consolidated onto Identity as a single
+  PHC-style encoded field (algorithm, iterations, salt, hash) instead of
+  separate `password` and `salt` columns.
+- Bad, because all four providers must be rewired to resolve via Identity; this
+  is a prerequisite phase (Phase 1) before user-merge.
+- Neutral, because the password scheme is unchanged when the credential moves
+  onto Identity: still PBKDF2-HMAC-SHA256 (600k iterations) with a per-user salt
+  and a `SECRET_KEY` pepper; only its storage location and encoding change.
+
+### Confirmation
+
+All four `server/auth/*AuthProvider.ts` resolve login through Identity with no
+remaining `User.findOne({ where: { email } })` login path; local password
+verifies against the PHC field stored on the Identity.
+
+## Pros and Cons of the Options
+
+### Keep email as the login key
+
+- Good, because no migration or auth rewrite is needed now.
+- Bad, because it is a structural constraint the user, auth, and member areas
+  keep paying for as they grow.
+- Bad, because account-merge stays impossible.
+
+### Multi-valued Identity model
+
+- Good, because it establishes the foundation the rest of the auth, user, members and role enhancements will build on.
+- Good, because login keys per provider stop colliding on email.
+- Bad, because it is the bulk of the effort (rewiring all four providers plus a
+  data migration).
+
+## More Information
+
+Phase 1 of a two-phase effort; Phase 2 is the merge (ADR 0002). Related: #171
+(multiple SSO methods at once), #170 (local registration), PR #183.

--- a/docs/adr/0002-user-merge-conflict-resolution.md
+++ b/docs/adr/0002-user-merge-conflict-resolution.md
@@ -1,0 +1,93 @@
+---
+status: proposed
+date: 2026-06-03
+decision-makers: Mark Rivera, Amndeep Singh Mann
+consulted: Aaron Lippold
+---
+
+# User-merge folds a source User into a non-Admin target, target-wins on conflicts
+
+## Context and Problem Statement
+
+Once a User can hold multiple Identities (ADR 0001), an Admin can merge two Users
+that are the same person. Merging raises conflicts across global Role, Member
+roles on shared nodes, preferences, tokens and sessions, and assignments. How
+should those conflicts resolve?
+
+## Decision Drivers
+
+- A merge must not silently strip access the person only reached through one of
+  the accounts.
+- The result must respect the "an Admin is never a Member" invariant.
+- Conflict resolution should be predictable and not depend on an undefined role
+  ordering.
+- An Admin needs visibility and an override before committing.
+
+## Considered Options
+
+- Most-permissive role wins.
+- Target's entire membership set wins, source memberships dropped.
+- Explicit admin choice per conflict.
+- Target-wins union.
+
+## Decision Outcome
+
+Chosen option: "Target-wins union", because it preserves every boundary the
+person could reach while keeping a deterministic default, with an escape hatch
+(per-role override in the preview) for the cases an Admin wants to change.
+
+The target (surviving User) must be a non-Admin; the source may be any Role and
+its global Role is discarded. Members are unioned, with the target's role winning
+on shared-node conflicts. The merge preview lists conflicts and allows per-role
+override. Eval and milestone assignments and notifications are reassigned and
+de-duped; source tokens are revoked and sessions invalidated; the target wins on
+preferences; the source is soft-retired with a `mergedIntoId`; the merge is
+audit-logged at `notice`.
+
+### Consequences
+
+- Good, because no boundary access is silently lost; conflicts surface in the
+  preview.
+- Good, because the outcome is deterministic without needing a defined role
+  ordering.
+- Bad, because it depends on the Admin-is-not-a-Member invariant, which is
+  enforced by separate work (API enforcement and SSO claim re-sync).
+- Neutral, because per-role override adds preview UI complexity.
+
+### Confirmation
+
+- Merge rejects an Admin target.
+- The source is left soft-retired with `mergedIntoId` set and its tokens and
+  sessions invalidated.
+- An audit entry at `notice` records source, target, and any overrides.
+- The unioned Members match the preview, including overrides.
+
+## Pros and Cons of the Options
+
+### Most-permissive role wins
+
+- Bad, because there is no defined ordering once TIR has custom Member roles, so
+  "most permissive" stops being meaningful.
+
+### Target's entire membership set wins, source memberships dropped
+
+- Good, because it is trivial to implement.
+- Bad, because it silently strips boundaries the person only reached through the
+  source, which defeats the purpose of merging.
+
+### Explicit admin choice per conflict
+
+- Good, because it is maximally precise.
+- Bad, because it is impractical at scale; kept only as the per-role override in
+  the preview.
+
+### Target-wins union
+
+- Good, because it is a deterministic default plus a per-role override.
+- Bad, because it requires building the preview and override UI.
+
+## More Information
+
+Requires the multi-identity model (ADR 0001). Depends on the Admin-is-not-a-Member
+invariant holding, enforced by separate work. Acceptance criteria for the
+user-merge feature issue derive from this ADR.


### PR DESCRIPTION
Two proposed ADRs (MADR format, status: proposed) from the user-merge design discussion. Opening as a PR so the records are reviewable before the design goes to a GitHub Discussion for wider input.

- ADR 0001 - multi-identity login: a User holds many Identities; login resolves provider + external key -> Identity -> User instead of by email. Foundation (Phase 1) for account-merge.
- ADR 0002 - user-merge conflict resolution: fold a source User into a non-Admin target, target-wins union of Members with preview + per-role override, source soft-retired with mergedIntoId, audit at notice. (Phase 2.)

Both are status: proposed - this PR is for reviewing the decisions, not adopting them yet. Related: #171, #170, _https://github.com/mitre/tir/pull/183#discussion_r3326284267_