### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
+The title drives the release and docs/CHANGELOG.md via semantic-release, so it
+matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
+ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
+-->
+
+## Summary
+
+<!-- What this PR does and why, in a sentence or two. -->
+
+## Changes
+
+<!-- Notable changes. For larger PRs, group them, e.g. Added / Changed / Fixed / Removed. -->
+
+## Testing
+
+<!-- How did you verify this change? -->
+
+## Related
+
+<!-- closes #..., relates to #..., discussion or ADR links -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,10 @@ ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
 ## Related
 
 <!-- closes #..., relates to #..., discussion or ADR links -->
+
+<!--
+Breaking change? Uncomment the line below and describe what breaks.
+Leave this commented out if nothing breaks.
+
+BREAKING CHANGE: what breaks and how to migrate
+-->


### PR DESCRIPTION
## Summary

Adds a pull request template so PR descriptions are consistent and PR titles follow Conventional Commits (the title drives the release and docs/CHANGELOG.md via semantic-release on squash merges).

## Changes

- Added .github/PULL_REQUEST_TEMPLATE.md with Summary / Changes / Testing / Related sections.
- Title reminder at the top covering the Conventional Commits types and the BREAKING CHANGE footer.

## Testing

Rendered the template by opening this PR with it.

## Related

Follows the issue-template standardization in #195. No CI enforcement added (reminder only).