### PR TITLE
fix(import): limit CKLB imports to baseline STIG libraries

### DIFF
--- a/server/utils/checklist.ts
+++ b/server/utils/checklist.ts
@@ -36,7 +36,13 @@ export async function importChecklistV3(
   try {
     for (const stigFromCkl of cklbData.stigs) {
       const cklStigId = stigFromCkl.stig_id;
-      const stigLibraryId = system?.dataValues.Boundary.StigLibraryId;
+      const stigLibraryId = system?.Boundary?.StigLibraryId;
+      if (!stigLibraryId) {
+        throw createError({
+          statusCode: 500,
+          statusMessage: "System does not have an assigned boundary STIG library",
+        });
+      }
       const stigMatchingCkl = await findStigByStigId(cklStigId, stigLibraryId);
 
       if (!stigMatchingCkl) {

--- a/server/utils/checklist.ts
+++ b/server/utils/checklist.ts
@@ -42,7 +42,7 @@ export async function importChecklistV3(
       if (!stigMatchingCkl) {
         throw createError({
           statusCode: 415,
-          statusMessage: `No STIG matching id "${stigMatchingCkl}" found in system's assigned Library`,
+          statusMessage: `No STIG matching id "${cklStigId}" found in system's assigned Library`,
         });
       }
 

--- a/server/utils/checklist.ts
+++ b/server/utils/checklist.ts
@@ -35,12 +35,9 @@ export async function importChecklistV3(
 
   try {
     for (const stigFromCkl of cklbData.stigs) {
-      let cklStigId = stigFromCkl.stig_id;
-      const stigMatchingCkl = await Stig.findOne({
-        where: {
-          stigid: stigFromCkl.stig_id,
-        },
-      });
+      const cklStigId = stigFromCkl.stig_id;
+      const stigLibraryId = system?.dataValues.Boundary.StigLibraryId;
+      const stigMatchingCkl = await findStigByStigId(cklStigId, stigLibraryId);
 
       if (!stigMatchingCkl) {
         throw createError({


### PR DESCRIPTION
<!--
Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
The title drives the release and docs/CHANGELOG.md via semantic-release, so it
matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
-->

## Summary

Fixes an issue where CKLB imports could apply STIGs that were not part of a system's assigned baseline. STIG matching is now restricted to the associated boundary STIG library to ensure only valid baseline STIGs are imported.

## Changes

Updated CKLB import logic to look up STIGs only within the system's associated boundary STIG library

## Testing

Verified only STIGs from the associated boundary STIG library were applied, STIGS applied count was correct under the systems tab

## Related

<!-- closes #..., relates to #..., discussion or ADR links -->

<!--
Breaking change? Uncomment the line below and describe what breaks.
Leave this commented out if nothing breaks.

BREAKING CHANGE: what breaks and how to migrate
-->
