### PR TITLE
chore: Update chore issue template type and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,7 +1,6 @@
 name: 🔧 Chore
 description: Internal work, refactor, or maintenance
-type: Task
-labels: ["chore"]
+type: Chore
 body:
   - type: textarea
     id: goal


### PR DESCRIPTION
## Summary

Fixes incorrect Issue Type assigned to Chore.  New types were created and this still uses the old type Task.
With the new types create, the labels are redundant an no longer used.  Removed for this type.

## Changes

- Template now sets type to "Chore"
- Template no longer assigns any labels.

## Testing

None

## Related

Fixes issues in PR #195