### PR TITLE
chore(tooltips): standardize auth tooltips with UTooltip

### DIFF
--- a/components/UI/RemoveProviderConfirm.vue
+++ b/components/UI/RemoveProviderConfirm.vue
@@ -4,15 +4,19 @@
     class="relative"
   >
     <!-- Trigger -->
-    <button
+    <UTooltip
       v-if="asIcon"
-      type="button"
-      title="Remove provider"
-      class="inline-flex items-center justify-center rounded-md p-1.5 text-gray-500 transition hover:bg-gray-100 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
-      @click="open = !open"
+      text="Remove provider"
     >
-      <TrashIcon class="h-4 w-4" />
-    </button>
+      <button
+        type="button"
+        aria-label="Remove provider"
+        class="inline-flex items-center justify-center rounded-md p-1.5 text-gray-500 transition hover:bg-gray-100 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
+        @click="open = !open"
+      >
+        <TrashIcon class="h-4 w-4" />
+      </button>
+    </UTooltip>
     <button
       v-else
       type="button"

--- a/components/UI/RemoveProviderConfirm.vue
+++ b/components/UI/RemoveProviderConfirm.vue
@@ -4,7 +4,7 @@
     class="relative"
   >
     <!-- Trigger -->
-    <UTooltip
+    <UITooltip
       v-if="asIcon"
       text="Remove provider"
     >
@@ -16,7 +16,7 @@
       >
         <TrashIcon class="h-4 w-4" />
       </button>
-    </UTooltip>
+    </UITooltip>
     <button
       v-else
       type="button"

--- a/components/UI/Tooltip.vue
+++ b/components/UI/Tooltip.vue
@@ -1,0 +1,24 @@
+<template>
+  <UTooltip
+    v-bind="$attrs"
+    @focusin="onFocusin"
+    @focusout="onFocusout"
+  >
+    <slot />
+    <template
+      v-if="$slots.text"
+      #text
+    >
+      <slot name="text" />
+    </template>
+  </UTooltip>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: "UITooltip", inheritAttrs: false });
+
+const onFocusin = (e: FocusEvent) =>
+  (e.currentTarget as HTMLElement).dispatchEvent(new MouseEvent("mouseenter"));
+const onFocusout = (e: FocusEvent) =>
+  (e.currentTarget as HTMLElement).dispatchEvent(new MouseEvent("mouseleave"));
+</script>

--- a/components/auth/OAuthProvider.vue
+++ b/components/auth/OAuthProvider.vue
@@ -152,18 +152,19 @@
               type="text"
               class="flex-1"
             />
-            <button
-              type="button"
-              class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
-              title="Fill with this server's callback URL"
-              @click="provider.callback = callbackUrl()"
-            >
-              <UIcon
-                name="i-heroicons-arrow-path"
-                class="h-3 w-3"
-              />
-              Fill
-            </button>
+            <UTooltip text="Fill with this server's callback URL">
+              <button
+                type="button"
+                class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
+                @click="provider.callback = callbackUrl()"
+              >
+                <UIcon
+                  name="i-heroicons-arrow-path"
+                  class="h-3 w-3"
+                />
+                Fill
+              </button>
+            </UTooltip>
           </div>
           <p class="text-xs text-gray-400">
             The default value usually works as-is. Register this URL as an allowed callback/redirect URL with your
@@ -220,15 +221,28 @@
         >
           {{ connectionTest?.loading ? "Testing…" : "Test Connection" }}
         </button>
-        <button
-          type="button"
-          :disabled="loginTest?.loading"
-          class="rounded border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-          title="Requires saved config — opens a popup to run the full OAuth login flow without affecting your current session"
-          @click="testLogin"
+        <UTooltip
+          :ui="{
+            width: 'max-w-none'
+          }"
         >
-          {{ loginTest?.loading ? "Waiting…" : "Test Login" }}
-        </button>
+          <span class="inline-flex">
+            <button
+              type="button"
+              :disabled="loginTest?.loading"
+              class="rounded border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              @click="testLogin"
+            >
+              {{ loginTest?.loading ? "Waiting…" : "Test Login" }}
+            </button>
+          </span>
+
+          <template #text>
+            <span class="whitespace-nowrap">
+              Requires saved config — opens a popup to run the full OAuth login flow without affecting your current session
+            </span>
+          </template>
+        </UTooltip>
       </div>
 
       <AuthConnectionTestResult :result="connectionTest" />

--- a/components/auth/OAuthProvider.vue
+++ b/components/auth/OAuthProvider.vue
@@ -152,7 +152,7 @@
               type="text"
               class="flex-1"
             />
-            <UTooltip text="Fill with this server's callback URL">
+            <UITooltip text="Fill with this server's callback URL">
               <button
                 type="button"
                 class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
@@ -164,7 +164,7 @@
                 />
                 Fill
               </button>
-            </UTooltip>
+            </UITooltip>
           </div>
           <p class="text-xs text-gray-400">
             The default value usually works as-is. Register this URL as an allowed callback/redirect URL with your
@@ -221,7 +221,7 @@
         >
           {{ connectionTest?.loading ? "Testing…" : "Test Connection" }}
         </button>
-        <UTooltip
+        <UITooltip
           :ui="{
             width: 'max-w-none'
           }"
@@ -242,7 +242,7 @@
               Requires saved config — opens a popup to run the full OAuth login flow without affecting your current session
             </span>
           </template>
-        </UTooltip>
+        </UITooltip>
       </div>
 
       <AuthConnectionTestResult :result="connectionTest" />

--- a/components/auth/OIDCProvider.vue
+++ b/components/auth/OIDCProvider.vue
@@ -98,18 +98,19 @@
               type="text"
               class="flex-1"
             />
-            <button
-              type="button"
-              class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
-              title="Fill with this server's callback URL"
-              @click="provider.callback = callbackUrl()"
-            >
-              <UIcon
-                name="i-heroicons-arrow-path"
-                class="h-3 w-3"
-              />
-              Fill
-            </button>
+            <UTooltip text="Fill with this server's callback URL">
+              <button
+                type="button"
+                class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
+                @click="provider.callback = callbackUrl()"
+              >
+                <UIcon
+                  name="i-heroicons-arrow-path"
+                  class="h-3 w-3"
+                />
+                Fill
+              </button>
+            </UTooltip>
           </div>
           <p class="text-xs text-gray-400">
             The default value usually works as-is. Register this URL as an allowed callback/redirect URL with your
@@ -203,15 +204,28 @@
         >
           {{ connectionTest?.loading ? "Testing…" : "Test Connection" }}
         </button>
-        <button
-          type="button"
-          :disabled="loginTest?.loading"
-          class="rounded border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-          title="Requires saved config — opens a popup to run the full OIDC login flow without affecting your current session"
-          @click="testLogin"
+        <UTooltip
+          :ui="{
+            width: 'max-w-none',
+          }"
         >
-          {{ loginTest?.loading ? "Waiting…" : "Test Login" }}
-        </button>
+          <span class="inline-flex">
+            <button
+              type="button"
+              :disabled="loginTest?.loading"
+              class="rounded border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              @click="testLogin"
+            >
+              {{ loginTest?.loading ? "Waiting…" : "Test Login" }}
+            </button>
+          </span>
+
+          <template #text>
+            <span class="whitespace-nowrap">
+              Requires saved config — opens a popup to run the full OIDC login flow without affecting your current session
+            </span>
+          </template>
+        </UTooltip>
       </div>
 
       <AuthConnectionTestResult :result="connectionTest" />

--- a/components/auth/OIDCProvider.vue
+++ b/components/auth/OIDCProvider.vue
@@ -98,7 +98,7 @@
               type="text"
               class="flex-1"
             />
-            <UTooltip text="Fill with this server's callback URL">
+            <UITooltip text="Fill with this server's callback URL">
               <button
                 type="button"
                 class="shrink-0 rounded border border-gray-300 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-800"
@@ -110,7 +110,7 @@
                 />
                 Fill
               </button>
-            </UTooltip>
+            </UITooltip>
           </div>
           <p class="text-xs text-gray-400">
             The default value usually works as-is. Register this URL as an allowed callback/redirect URL with your
@@ -204,7 +204,7 @@
         >
           {{ connectionTest?.loading ? "Testing…" : "Test Connection" }}
         </button>
-        <UTooltip
+        <UITooltip
           :ui="{
             width: 'max-w-none',
           }"
@@ -225,7 +225,7 @@
               Requires saved config — opens a popup to run the full OIDC login flow without affecting your current session
             </span>
           </template>
-        </UTooltip>
+        </UITooltip>
       </div>
 
       <AuthConnectionTestResult :result="connectionTest" />


### PR DESCRIPTION
<!--
Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
The title drives the release and docs/CHANGELOG.md via semantic-release, so it
matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
-->

## Summary

Replaces native HTML title-attribute tooltips in auth components with UTooltip to standardize tooltip behavior and support browser zoom scaling.

## Changes

- Replace native title tooltips with UTooltip in OAuth and OIDC provider components
- Replace native title tooltip on the remove provider action
- Preserve accessibility for icon-only actions with existing aria-labels
- Ensure long tooltip content is displayed correctly

## Testing

- Verified tooltips display on hover
- Verified tooltip content scales with browser zoom
- Verified long tooltip text is no longer truncated

## Related

Related: #191

<!--
Breaking change? Uncomment the line below and describe what breaks.
Leave this commented out if nothing breaks.

BREAKING CHANGE: what breaks and how to migrate
-->
