### PR TITLE
fix(users): reset PostgreSQL ID sequence after seeding

### DIFF
--- a/db/seeders/2023.11.22T05.09.28.Users.js
+++ b/db/seeders/2023.11.22T05.09.28.Users.js
@@ -40,6 +40,15 @@ const users = [
 ];
 export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().bulkInsert("Users", users);
+
+  if (sequelize.getDialect() === "postgres") {
+    await sequelize.query(`
+      SELECT setval(
+        pg_get_serial_sequence('"Users"', 'id'),
+        (SELECT MAX(id) FROM "Users")
+      );
+    `);
+  }
 };
 export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().bulkDelete("Users", { id: users.map((s) => s.id) });


### PR DESCRIPTION
<!--
Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
The title drives the release and docs/CHANGELOG.md via semantic-release, so it
matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
-->

## Summary

<!-- What this PR does and why, in a sentence or two. -->
Resets the PostgreSQL Users ID sequence after seeding the default admin and user accounts so newly created users receive the next available ID. This prevents duplicate key conflicts caused by the sequence remaining behind manually seeded IDs.

## Changes

<!-- Notable changes. For larger PRs, group them, e.g. Added / Changed / Fixed / Removed. -->

- Added a PostgreSQL-specific sequence reset after seeding the default users.
- Ensures the Users ID sequence is synchronized with the highest existing user ID.
- Leaves SQLite behavior unchanged.

## Testing

<!-- How did you verify this change? -->

- Seeded a PostgreSQL database with the default users.
- Verified the Users ID sequence is advanced to the current maximum ID after seeding.
- Confirmed newly created users are assigned the next available ID on the first insert without duplicate key errors.

## Related

<!-- closes #..., relates to #..., discussion or ADR links -->
Closes: #210 

<!--
Breaking change? Uncomment the line below and describe what breaks.
Leave this commented out if nothing breaks.

BREAKING CHANGE: what breaks and how to migrate
-->
