### PR TITLE
 fix(db): remove hard varchar length limits and stop migrations importing the umzug instance

### DIFF
--- a/db/migrations/2023.11.10T01.46.59.UserRoles.js
+++ b/db/migrations/2023.11.10T01.46.59.UserRoles.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("UserRoles", {
     id: {
       type: DataTypes.INTEGER,
@@ -24,6 +23,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("UserRoles");
 };

--- a/db/migrations/2023.11.10T01.46.59.UserRoles.js
+++ b/db/migrations/2023.11.10T01.46.59.UserRoles.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("UserRoles", {
     id: {
@@ -10,16 +10,16 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.11T21.12.42.Users.js
+++ b/db/migrations/2023.11.11T21.12.42.Users.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Users", {
     id: {
@@ -9,20 +9,20 @@ export const up = async () => {
       autoIncrement: true,
     },
     firstName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     email: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     password: {
-      type: DataTypes.STRING(128),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     UserRoleId: {
@@ -35,11 +35,11 @@ export const up = async () => {
       onDelete: "SET NULL",
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.11T21.12.42.Users.js
+++ b/db/migrations/2023.11.11T21.12.42.Users.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Users", {
     id: {
       type: DataTypes.INTEGER,
@@ -44,6 +43,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Users");
 };

--- a/db/migrations/2023.11.11T22.59.04.Tier.js
+++ b/db/migrations/2023.11.11T22.59.04.Tier.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Tiers", {
     id: {
       type: DataTypes.INTEGER,
@@ -46,6 +45,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Tiers");
 };

--- a/db/migrations/2023.11.11T22.59.04.Tier.js
+++ b/db/migrations/2023.11.11T22.59.04.Tier.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Tiers", {
     id: {
@@ -10,7 +10,7 @@ export const up = async () => {
       allowNull: false,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -37,11 +37,11 @@ export const up = async () => {
       onDelete: "SET NULL",
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.11T23.08.46.Boundaries.js
+++ b/db/migrations/2023.11.11T23.08.46.Boundaries.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Boundaries", {
     id: {
       type: DataTypes.INTEGER,
@@ -44,6 +43,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Boundaries");
 };

--- a/db/migrations/2023.11.11T23.08.46.Boundaries.js
+++ b/db/migrations/2023.11.11T23.08.46.Boundaries.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Boundaries", {
     id: {
@@ -10,16 +10,16 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     ownerId: {

--- a/db/migrations/2023.11.11T23.08.58.Systems.js
+++ b/db/migrations/2023.11.11T23.08.58.Systems.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Systems", {
     id: {
@@ -10,18 +10,18 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
-    hostname: DataTypes.STRING,
+    hostname: DataTypes.TEXT,
     BoundaryId: {
       type: DataTypes.INTEGER,
       references: {

--- a/db/migrations/2023.11.11T23.08.58.Systems.js
+++ b/db/migrations/2023.11.11T23.08.58.Systems.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Systems", {
     id: {
       type: DataTypes.INTEGER,
@@ -33,6 +32,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Systems");
 };

--- a/db/migrations/2023.11.11T23.20.33.BoundaryUserRoles.js
+++ b/db/migrations/2023.11.11T23.20.33.BoundaryUserRoles.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("BoundaryRoles", {
     id: {
@@ -10,16 +10,16 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.11T23.20.33.BoundaryUserRoles.js
+++ b/db/migrations/2023.11.11T23.20.33.BoundaryUserRoles.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("BoundaryRoles", {
     id: {
       type: DataTypes.INTEGER,
@@ -55,7 +54,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("BoundaryRoles");
   await sequelize.getQueryInterface().dropTable("Boundary_Users");
 };

--- a/db/migrations/2023.11.11T23.20.42.TierUserRoles.js
+++ b/db/migrations/2023.11.11T23.20.42.TierUserRoles.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("TierRoles", {
     id: {
       type: DataTypes.INTEGER,
@@ -56,7 +55,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("TierRoles");
   await sequelize.getQueryInterface().dropTable("Tier_Users");
 };

--- a/db/migrations/2023.11.11T23.20.42.TierUserRoles.js
+++ b/db/migrations/2023.11.11T23.20.42.TierUserRoles.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("TierRoles", {
     id: {
@@ -11,16 +11,16 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.12T00.58.33.Stigs.js
+++ b/db/migrations/2023.11.12T00.58.33.Stigs.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Stigs", {
     id: {
       type: DataTypes.INTEGER,
@@ -174,6 +173,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Stigs");
 };

--- a/db/migrations/2023.11.12T00.58.33.Stigs.js
+++ b/db/migrations/2023.11.12T00.58.33.Stigs.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Stigs", {
     id: {
@@ -11,100 +11,100 @@ export const up = async () => {
       allowNull: false,
     },
     dc: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xsi: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     cpe: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xhtml: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dsig: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     schemaLocation: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     stigid: {
       // Same as Benchmark.id in XML
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lang: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xmlns: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     status: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     status__date: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING(2000),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     notice__id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     notice__lang: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     front_matter: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     rear_matter: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__href: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__publisher: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__source: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__release_info: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__generator: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__conventionsVersion: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     stigRelease: {
@@ -112,11 +112,11 @@ export const up = async () => {
       allowNull: false,
     },
     stigDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     filename: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     MAC1C: {
@@ -165,11 +165,11 @@ export const up = async () => {
       defaultValue: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.12T13.50.25.Stig_Systems.js
+++ b/db/migrations/2023.11.12T13.50.25.Stig_Systems.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Stig_Systems", {
     StigId: {

--- a/db/migrations/2023.11.12T13.50.25.Stig_Systems.js
+++ b/db/migrations/2023.11.12T13.50.25.Stig_Systems.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Stig_Systems", {
     StigId: {
       type: DataTypes.INTEGER,
@@ -25,6 +24,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Stig_Systems");
 };

--- a/db/migrations/2023.11.12T19.11.38.StigLibrary.js
+++ b/db/migrations/2023.11.12T19.11.38.StigLibrary.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("StigLibraries", {
     id: {
       type: DataTypes.INTEGER,
@@ -78,7 +77,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().removeColumn("Boundaries", "StigLibraryId");
     await sequelize.getQueryInterface().changeColumn("Boundaries", "TierId", {

--- a/db/migrations/2023.11.12T19.11.38.StigLibrary.js
+++ b/db/migrations/2023.11.12T19.11.38.StigLibrary.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("StigLibraries", {
     id: {
@@ -11,12 +11,12 @@ export const up = async () => {
       allowNull: false,
     },
     filename: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
     hash: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
@@ -26,7 +26,7 @@ export const up = async () => {
       allowNull: true,
     },
     libraryDate: {
-      type: DataTypes.STRING(29),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     version: {
@@ -34,15 +34,15 @@ export const up = async () => {
       allowNull: true,
     },
     importedDate: {
-      type: DataTypes.STRING(29),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -93,14 +93,14 @@ export const down = async () => {
     });
   } else {
     await sequelize.query(
-      "CREATE TABLE `Boundaries_backup` (`creationDate` VARCHAR(29) NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastUpdate` VARCHAR(29) NOT NULL, `name` VARCHAR(255) NOT NULL UNIQUE, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);",
+      "CREATE TABLE `Boundaries_backup` (`creationDate` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastUpdate` TEXT NOT NULL, `name` TEXT NOT NULL UNIQUE, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Boundaries_backup` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId` FROM `Boundaries`;",
     );
     await sequelize.query("DROP TABLE `Boundaries`;");
     await sequelize.query(
-      "CREATE TABLE `Boundaries` (`creationDate` VARCHAR(29) NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastUpdate` VARCHAR(29) NOT NULL, `name` VARCHAR(255) NOT NULL UNIQUE, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);",
+      "CREATE TABLE `Boundaries` (`creationDate` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastUpdate` TEXT NOT NULL, `name` TEXT NOT NULL UNIQUE, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Boundaries` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId` FROM `Boundaries_backup`;",

--- a/db/migrations/2023.11.13T19.48.25.StigData.js
+++ b/db/migrations/2023.11.13T19.48.25.StigData.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("StigData", {
     id: {
       type: DataTypes.INTEGER,
@@ -165,7 +164,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("StigData");
   await sequelize.getQueryInterface().dropTable("Stig_StigData");
 };

--- a/db/migrations/2023.11.13T19.48.25.StigData.js
+++ b/db/migrations/2023.11.13T19.48.25.StigData.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("StigData", {
     id: {
@@ -8,19 +8,19 @@ export const up = async () => {
       primaryKey: true,
     },
     vuln_num: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     group_title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -30,11 +30,11 @@ export const up = async () => {
       allowNull: true,
     },
     weight: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_ver: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_title: {
@@ -46,19 +46,19 @@ export const up = async () => {
       allowNull: false,
     },
     false_positives: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     false_negatives: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     documentable: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     mitigations: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     security_override_guidance: {
@@ -66,27 +66,27 @@ export const up = async () => {
       allowNull: true,
     },
     potential_impact: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     third_party_tools: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     mitigation_control: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     responsibility: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     ia_controls: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     check__system: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     check_check_content: {
@@ -94,15 +94,15 @@ export const up = async () => {
       allowNull: false,
     },
     check_check_content_ref__name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     check_check_content_ref__href: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fix__id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fixtext: {
@@ -110,35 +110,35 @@ export const up = async () => {
       allowNull: false,
     },
     fixtext__fixref: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reference__dc_identifier: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reference__dc_publisher: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reference__dc_subject: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reference__dc_title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reference__dc_type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.13T19.52.33.StigResponsibilies.js
+++ b/db/migrations/2023.11.13T19.52.33.StigResponsibilies.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("StigResponsibilities", {
     id: {
       type: DataTypes.INTEGER,
@@ -45,7 +44,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("StigResponsibilities");
   await sequelize.getQueryInterface().dropTable("StigData_StigResponsibilities");
 };

--- a/db/migrations/2023.11.13T19.52.33.StigResponsibilies.js
+++ b/db/migrations/2023.11.13T19.52.33.StigResponsibilies.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("StigResponsibilities", {
     id: {
@@ -9,16 +9,16 @@ export const up = async () => {
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2023.11.13T19.54.58.Assessments.js
+++ b/db/migrations/2023.11.13T19.54.58.Assessments.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Assessments", {
     id: {
@@ -9,27 +9,27 @@ export const up = async () => {
       primaryKey: true,
     },
     classification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     customname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     uuid: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     comment: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {

--- a/db/migrations/2023.11.13T19.54.58.Assessments.js
+++ b/db/migrations/2023.11.13T19.54.58.Assessments.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Assessments", {
     id: {
       type: DataTypes.INTEGER,
@@ -52,6 +51,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Assessments");
 };

--- a/db/migrations/2023.11.13T20.36.29.AssessmentItems.js
+++ b/db/migrations/2023.11.13T20.36.29.AssessmentItems.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("AssessmentItems", {
     id: {
@@ -25,18 +25,18 @@ export const up = async () => {
       allowNull: true,
     },
     severity_justification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     current: {
       type: DataTypes.BOOLEAN,
       defaultValue: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     previousId: {

--- a/db/migrations/2023.11.13T20.36.29.AssessmentItems.js
+++ b/db/migrations/2023.11.13T20.36.29.AssessmentItems.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("AssessmentItems", {
     id: {
       type: DataTypes.INTEGER,
@@ -66,6 +65,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("AssessmentItems");
 };

--- a/db/migrations/2023.11.14T04.23.56.Evaluations.js
+++ b/db/migrations/2023.11.14T04.23.56.Evaluations.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Evaluations", {
     id: {
       type: DataTypes.INTEGER,
@@ -48,6 +47,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Evaluations");
 };

--- a/db/migrations/2023.11.14T04.23.56.Evaluations.js
+++ b/db/migrations/2023.11.14T04.23.56.Evaluations.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Evaluations", {
     id: {
@@ -9,23 +9,23 @@ export const up = async () => {
       primaryKey: true,
     },
     classification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     customname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     comment: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     BoundaryId: {

--- a/db/migrations/2023.11.14T04.26.48.EvaluationItems.js
+++ b/db/migrations/2023.11.14T04.26.48.EvaluationItems.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("EvaluationItems", {
     id: {
@@ -14,10 +14,10 @@ export const up = async () => {
       allowNull: false,
     },
     finding_details: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     comments: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     severity_override: {
       type: DataTypes.ENUM,
@@ -25,25 +25,25 @@ export const up = async () => {
       allowNull: true,
     },
     severity_justification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     Office_Org: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Resources_Required: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Scheduled_Completion_Date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
     },
     Milestone_Changes: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Poam_Comments: {
-      type: DataTypes.STRING(1024),
+      type: DataTypes.TEXT,
     },
     Mitigations: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Severity: {
       type: DataTypes.ENUM,
@@ -66,7 +66,7 @@ export const up = async () => {
       allowNull: true,
     },
     Impact_Description: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Residual_Risk_Level: {
       type: DataTypes.ENUM,
@@ -74,14 +74,14 @@ export const up = async () => {
       allowNull: true,
     },
     Recommendations: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     EvaluationId: {
@@ -111,19 +111,19 @@ export const up = async () => {
       allowNull: false,
     },
     item: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     completion_date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     EvaluationItemId: {

--- a/db/migrations/2023.11.14T04.26.48.EvaluationItems.js
+++ b/db/migrations/2023.11.14T04.26.48.EvaluationItems.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("EvaluationItems", {
     id: {
       type: DataTypes.INTEGER,
@@ -160,7 +159,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Milestones");
   await sequelize.getQueryInterface().dropTable("EvaluationItems");
   await sequelize.getQueryInterface().dropTable("EvaluationItem_Milestones");

--- a/db/migrations/2023.11.14T05.08.10.Timezones.js
+++ b/db/migrations/2023.11.14T05.08.10.Timezones.js
@@ -1,20 +1,20 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Timezones", {
     id: {
       type: DataTypes.INTEGER,
       primaryKey: true,
     },
-    name: DataTypes.STRING(64),
-    abbreviation: DataTypes.STRING(5),
+    name: DataTypes.TEXT,
+    abbreviation: DataTypes.TEXT,
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -33,14 +33,14 @@ export const down = async () => {
     await sequelize.getQueryInterface().removeColumn("Users", "TimezoneId");
   } else {
     await sequelize.query(
-      "CREATE TABLE `Users_backup` (`creationDate` VARCHAR(29) NOT NULL, `email` VARCHAR(255) NOT NULL UNIQUE, `firstName` VARCHAR(255) NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastName` VARCHAR(255) NOT NULL, `lastUpdate` VARCHAR(29) NOT NULL, `password` VARCHAR(128), `UserRoleId` INTEGER REFERENCES `UserRoles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE);",
+      "CREATE TABLE `Users_backup` (`creationDate` TEXT NOT NULL, `email` TEXT NOT NULL UNIQUE, `firstName` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastName` TEXT NOT NULL, `lastUpdate` TEXT NOT NULL, `password` TEXT, `UserRoleId` INTEGER REFERENCES `UserRoles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Users_backup` SELECT `creationDate`, `email`, `firstname` , `id`, `lastName`, `lastUpdate`, `password`, `UserRoleId` FROM `Users`;",
     );
     await sequelize.query("DROP TABLE `Users`;");
     await sequelize.query(
-      "CREATE TABLE `Users` (`creationDate` VARCHAR(29) NOT NULL, `email` VARCHAR(255) NOT NULL UNIQUE, `firstName` VARCHAR(255) NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastName` VARCHAR(255) NOT NULL, `lastUpdate` VARCHAR(29) NOT NULL, `password` VARCHAR(128), `UserRoleId` INTEGER REFERENCES `UserRoles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE);",
+      "CREATE TABLE `Users` (`creationDate` TEXT NOT NULL, `email` TEXT NOT NULL UNIQUE, `firstName` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `lastName` TEXT NOT NULL, `lastUpdate` TEXT NOT NULL, `password` TEXT, `UserRoleId` INTEGER REFERENCES `UserRoles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Users` SELECT `creationDate`, `email`, `firstname` , `id`, `lastName`, `lastUpdate`, `password`, `UserRoleId` FROM `Users_backup`;",

--- a/db/migrations/2023.11.14T05.08.10.Timezones.js
+++ b/db/migrations/2023.11.14T05.08.10.Timezones.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Timezones", {
     id: {
       type: DataTypes.INTEGER,
@@ -28,7 +27,7 @@ export const up = async () => {
     onDelete: "SET NULL",
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().removeColumn("Users", "TimezoneId");
   } else {

--- a/db/migrations/2023.11.28T19.38.18.EvalutionPrune.js
+++ b/db/migrations/2023.11.28T19.38.18.EvalutionPrune.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   if (sequelize.getDialect() === "postgres") {
     await sequelize.getQueryInterface().removeColumn("EvaluationItems", "status");
     await sequelize.getQueryInterface().removeColumn("EvaluationItems", "finding_details");
@@ -27,7 +26,7 @@ export const up = async () => {
     await sequelize.query("DROP TABLE `EvaluationItems_backup`;");
   }
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().addColumn("EvaluationItems", "status", {
     type: DataTypes.ENUM,
     values: ["Not_Reviewed", "Open", "NotAFinding", "Not_Applicable", "Not_Set"],

--- a/db/migrations/2023.11.28T19.38.18.EvalutionPrune.js
+++ b/db/migrations/2023.11.28T19.38.18.EvalutionPrune.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   if (sequelize.getDialect() === "postgres") {
     await sequelize.getQueryInterface().removeColumn("EvaluationItems", "status");
@@ -12,14 +12,14 @@ export const up = async () => {
     await sequelize.query('DROP TYPE IF EXISTS public."enum_EvaluationItems_status";');
   } else {
     await sequelize.query(
-      `CREATE TABLE IF NOT EXISTS 'EvaluationItems_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'Office_Org' VARCHAR(256), 'Resources_Required' VARCHAR(256), 'Scheduled_Completion_Date' DATETIME, 'Milestone_Changes' VARCHAR(256), 'Poam_Comments' VARCHAR(1024), 'Mitigations' VARCHAR(256), 'Severity' TEXT, 'Relevance_of_Threat' TEXT, 'Likelihood' TEXT, 'Impact' TEXT, 'Impact_Description' VARCHAR(256), 'Residual_Risk_Level' TEXT, 'Recommendations' VARCHAR(256), 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
+      `CREATE TABLE IF NOT EXISTS 'EvaluationItems_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'Office_Org' TEXT, 'Resources_Required' TEXT, 'Scheduled_Completion_Date' DATETIME, 'Milestone_Changes' TEXT, 'Poam_Comments' TEXT, 'Mitigations' TEXT, 'Severity' TEXT, 'Relevance_of_Threat' TEXT, 'Likelihood' TEXT, 'Impact' TEXT, 'Impact_Description' TEXT, 'Residual_Risk_Level' TEXT, 'Recommendations' TEXT, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `EvaluationItems_backup` SELECT `id`, `Office_Org`, `Resources_Required`, `Scheduled_Completion_Date`, `Milestone_Changes`, `Poam_Comments`, `Mitigations`, `Severity`, `Relevance_of_Threat`, `Likelihood`, `Impact`, `Impact_Description`, `Residual_Risk_Level`, `Recommendations`, `lastUpdate`, `creationDate`, `EvaluationId`, `StigDatumId` FROM `EvaluationItems`;",
     );
     await sequelize.query("DROP TABLE `EvaluationItems`;");
     await sequelize.query(
-      `CREATE TABLE IF NOT EXISTS 'EvaluationItems' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'Office_Org' VARCHAR(256), 'Resources_Required' VARCHAR(256), 'Scheduled_Completion_Date' DATETIME, 'Milestone_Changes' VARCHAR(256), 'Poam_Comments' VARCHAR(1024), 'Mitigations' VARCHAR(256), 'Severity' TEXT, 'Relevance_of_Threat' TEXT, 'Likelihood' TEXT, 'Impact' TEXT, 'Impact_Description' VARCHAR(256), 'Residual_Risk_Level' TEXT, 'Recommendations' VARCHAR(256), 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
+      `CREATE TABLE IF NOT EXISTS 'EvaluationItems' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'Office_Org' TEXT, 'Resources_Required' TEXT, 'Scheduled_Completion_Date' DATETIME, 'Milestone_Changes' TEXT, 'Poam_Comments' TEXT, 'Mitigations' TEXT, 'Severity' TEXT, 'Relevance_of_Threat' TEXT, 'Likelihood' TEXT, 'Impact' TEXT, 'Impact_Description' TEXT, 'Residual_Risk_Level' TEXT, 'Recommendations' TEXT, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `EvaluationItems` SELECT `id`, `Office_Org`, `Resources_Required`, `Scheduled_Completion_Date`, `Milestone_Changes`, `Poam_Comments`, `Mitigations`, `Severity`, `Relevance_of_Threat`, `Likelihood`, `Impact`, `Impact_Description`, `Residual_Risk_Level`, `Recommendations`, `lastUpdate`, `creationDate`, `EvaluationId`, `StigDatumId` FROM `EvaluationItems_backup`;",
@@ -34,10 +34,10 @@ export const down = async () => {
     allowNull: false,
   });
   await sequelize.getQueryInterface().addColumn("EvaluationItems", "finding_details", {
-    type: DataTypes.STRING,
+    type: DataTypes.TEXT,
   });
   await sequelize.getQueryInterface().addColumn("EvaluationItems", "comments", {
-    type: DataTypes.STRING,
+    type: DataTypes.TEXT,
   });
   await sequelize.getQueryInterface().addColumn("EvaluationItems", "severity_override", {
     type: DataTypes.ENUM,
@@ -45,6 +45,6 @@ export const down = async () => {
     allowNull: true,
   });
   await sequelize.getQueryInterface().addColumn("EvaluationItems", "severity_justification", {
-    type: DataTypes.STRING,
+    type: DataTypes.TEXT,
   });
 };

--- a/db/migrations/2023.12.06T00.58.01.Override.js
+++ b/db/migrations/2023.12.06T00.58.01.Override.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Overrides", {
     id: {
@@ -15,11 +15,11 @@ export const up = async () => {
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {

--- a/db/migrations/2023.12.06T00.58.01.Override.js
+++ b/db/migrations/2023.12.06T00.58.01.Override.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Overrides", {
     id: {
       type: DataTypes.INTEGER,
@@ -42,6 +41,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Overrides");
 };

--- a/db/migrations/2024.01.08T05.54.40.StigReferences.js
+++ b/db/migrations/2024.01.08T05.54.40.StigReferences.js
@@ -1,17 +1,17 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   if (sequelize.getDialect() === "sqlite") {
     await sequelize.query(
-      `CREATE TABLE 'StigData_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' VARCHAR(255) NOT NULL, 'group_title' VARCHAR(255) NOT NULL, 'description' VARCHAR(255) NOT NULL, 'rule_id' VARCHAR(255) NOT NULL UNIQUE, 'severity' TEXT, 'weight' VARCHAR(255) NOT NULL, 'rule_ver' VARCHAR(255) NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' VARCHAR(255), 'false_negatives' VARCHAR(255), 'documentable' VARCHAR(255) NOT NULL, 'mitigations' VARCHAR(255), 'security_override_guidance' TEXT, 'potential_impact' VARCHAR(255), 'third_party_tools' VARCHAR(255), 'mitigation_control' VARCHAR(255), 'responsibility' VARCHAR(255), 'ia_controls' VARCHAR(255), 'check__system' VARCHAR(255) NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' VARCHAR(255) NOT NULL, 'check_check_content_ref__href' VARCHAR(255) NOT NULL, 'fix__id' VARCHAR(255) NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' VARCHAR(255) NOT NULL, 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL);`,
+      `CREATE TABLE 'StigData_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' TEXT NOT NULL, 'group_title' TEXT NOT NULL, 'description' TEXT NOT NULL, 'rule_id' TEXT NOT NULL UNIQUE, 'severity' TEXT, 'weight' TEXT NOT NULL, 'rule_ver' TEXT NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' TEXT, 'false_negatives' TEXT, 'documentable' TEXT NOT NULL, 'mitigations' TEXT, 'security_override_guidance' TEXT, 'potential_impact' TEXT, 'third_party_tools' TEXT, 'mitigation_control' TEXT, 'responsibility' TEXT, 'ia_controls' TEXT, 'check__system' TEXT NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' TEXT NOT NULL, 'check_check_content_ref__href' TEXT NOT NULL, 'fix__id' TEXT NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' TEXT NOT NULL, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL);`,
     );
     await sequelize.query(
       "INSERT INTO `StigData_backup` SELECT `id`, `vuln_num`, `group_title`, `description`, `rule_id`, `severity`, `weight`, `rule_ver`, `rule_title`, `vuln_discuss`, `false_positives`, `false_negatives`, `documentable`, `mitigations`, `security_override_guidance`, `potential_impact`, `third_party_tools`, `mitigation_control`, `responsibility`, `ia_controls`, `check__system`, `check_check_content`, `check_check_content_ref__name`, `check_check_content_ref__href`, `fix__id`, `fixtext`, `fixtext__fixref`, `lastUpdate`, `creationDate` FROM `StigData`;",
     );
     await sequelize.query("DROP TABLE `StigData`;");
     await sequelize.query(
-      `CREATE TABLE 'StigData' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' VARCHAR(255) NOT NULL, 'group_title' VARCHAR(255) NOT NULL, 'description' VARCHAR(255) NOT NULL, 'rule_id' VARCHAR(255) NOT NULL UNIQUE, 'severity' TEXT, 'weight' VARCHAR(255) NOT NULL, 'rule_ver' VARCHAR(255) NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' VARCHAR(255), 'false_negatives' VARCHAR(255), 'documentable' VARCHAR(255) NOT NULL, 'mitigations' VARCHAR(255), 'security_override_guidance' TEXT, 'potential_impact' VARCHAR(255), 'third_party_tools' VARCHAR(255), 'mitigation_control' VARCHAR(255), 'responsibility' VARCHAR(255), 'ia_controls' VARCHAR(255), 'check__system' VARCHAR(255) NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' VARCHAR(255) NOT NULL, 'check_check_content_ref__href' VARCHAR(255) NOT NULL, 'fix__id' VARCHAR(255) NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' VARCHAR(255) NOT NULL, 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL);`,
+      `CREATE TABLE 'StigData' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' TEXT NOT NULL, 'group_title' TEXT NOT NULL, 'description' TEXT NOT NULL, 'rule_id' TEXT NOT NULL UNIQUE, 'severity' TEXT, 'weight' TEXT NOT NULL, 'rule_ver' TEXT NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' TEXT, 'false_negatives' TEXT, 'documentable' TEXT NOT NULL, 'mitigations' TEXT, 'security_override_guidance' TEXT, 'potential_impact' TEXT, 'third_party_tools' TEXT, 'mitigation_control' TEXT, 'responsibility' TEXT, 'ia_controls' TEXT, 'check__system' TEXT NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' TEXT NOT NULL, 'check_check_content_ref__href' TEXT NOT NULL, 'fix__id' TEXT NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' TEXT NOT NULL, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL);`,
     );
     await sequelize.query(
       "INSERT INTO `StigData` SELECT `id`, `vuln_num`, `group_title`, `description`, `rule_id`, `severity`, `weight`, `rule_ver`, `rule_title`, `vuln_discuss`, `false_positives`, `false_negatives`, `documentable`, `mitigations`, `security_override_guidance`, `potential_impact`, `third_party_tools`, `mitigation_control`, `responsibility`, `ia_controls`, `check__system`, `check_check_content`, `check_check_content_ref__name`, `check_check_content_ref__href`, `fix__id`, `fixtext`, `fixtext__fixref`, `lastUpdate`, `creationDate` FROM `StigData_backup`;",
@@ -32,31 +32,31 @@ export const up = async () => {
       autoIncrement: true,
     },
     dc_identifier: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_publisher: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_subject: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -86,30 +86,30 @@ export const up = async () => {
 export const down = async () => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_identifier", {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     });
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_publisher", {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     });
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_subject", {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     });
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_title", {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     });
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_type", {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     });
   } else {
     await sequelize.query(
-      `CREATE TABLE 'StigData_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' VARCHAR(255) NOT NULL, 'group_title' VARCHAR(255) NOT NULL, 'description' VARCHAR(255) NOT NULL, 'rule_id' VARCHAR(255) NOT NULL UNIQUE, 'severity' TEXT, 'weight' VARCHAR(255) NOT NULL, 'rule_ver' VARCHAR(255) NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' VARCHAR(255), 'false_negatives' VARCHAR(255), 'documentable' VARCHAR(255) NOT NULL, 'mitigations' VARCHAR(255), 'security_override_guidance' TEXT, 'potential_impact' VARCHAR(255), 'third_party_tools' VARCHAR(255), 'mitigation_control' VARCHAR(255), 'responsibility' VARCHAR(255), 'ia_controls' VARCHAR(255), 'check__system' VARCHAR(255) NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' VARCHAR(255) NOT NULL, 'check_check_content_ref__href' VARCHAR(255) NOT NULL, 'fix__id' VARCHAR(255) NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' VARCHAR(255) NOT NULL , 'reference__dc_identifier' VARCHAR(255) NOT NULL DEFAULT "", 'reference__dc_publisher' VARCHAR(255) NOT NULL DEFAULT "", 'reference__dc_subject' VARCHAR(255) NOT NULL DEFAULT "", 'reference__dc_title' VARCHAR(255) NOT NULL DEFAULT "", 'reference__dc_type' VARCHAR(255) NOT NULL DEFAULT "", 'lastUpdate' VARCHAR${DATETIME_LENGTH} NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL);`,
+      `CREATE TABLE 'StigData_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' TEXT NOT NULL, 'group_title' TEXT NOT NULL, 'description' TEXT NOT NULL, 'rule_id' TEXT NOT NULL UNIQUE, 'severity' TEXT, 'weight' TEXT NOT NULL, 'rule_ver' TEXT NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' TEXT, 'false_negatives' TEXT, 'documentable' TEXT NOT NULL, 'mitigations' TEXT, 'security_override_guidance' TEXT, 'potential_impact' TEXT, 'third_party_tools' TEXT, 'mitigation_control' TEXT, 'responsibility' TEXT, 'ia_controls' TEXT, 'check__system' TEXT NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' TEXT NOT NULL, 'check_check_content_ref__href' TEXT NOT NULL, 'fix__id' TEXT NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' TEXT NOT NULL , 'reference__dc_identifier' TEXT NOT NULL DEFAULT "", 'reference__dc_publisher' TEXT NOT NULL DEFAULT "", 'reference__dc_subject' TEXT NOT NULL DEFAULT "", 'reference__dc_title' TEXT NOT NULL DEFAULT "", 'reference__dc_type' TEXT NOT NULL DEFAULT "", 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL);`,
     );
     await sequelize.query(
       "INSERT INTO `StigData_backup` SELECT `id`, `vuln_num`, `group_title`, `description`, `rule_id`, `severity`, `weight`, `rule_ver`, `rule_title`, `vuln_discuss`, `false_positives`, `false_negatives`, `documentable`, `mitigations`, `security_override_guidance`, `potential_impact`, `third_party_tools`, `mitigation_control`, `responsibility`, `ia_controls`, `check__system`, `check_check_content`, `check_check_content_ref__name`, `check_check_content_ref__href`, `fix__id`, `fixtext`, `fixtext__fixref`, '', '', '', '', '', `lastUpdate`, `creationDate` FROM `StigData`;",
     );
     await sequelize.query("DROP TABLE `StigData`;");
     await sequelize.query(
-      `CREATE TABLE 'StigData' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' VARCHAR(255) NOT NULL, 'group_title' VARCHAR(255) NOT NULL, 'description' VARCHAR(255) NOT NULL, 'rule_id' VARCHAR(255) NOT NULL UNIQUE, 'severity' TEXT, 'weight' VARCHAR(255) NOT NULL, 'rule_ver' VARCHAR(255) NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' VARCHAR(255), 'false_negatives' VARCHAR(255), 'documentable' VARCHAR(255) NOT NULL, 'mitigations' VARCHAR(255), 'security_override_guidance' TEXT, 'potential_impact' VARCHAR(255), 'third_party_tools' VARCHAR(255), 'mitigation_control' VARCHAR(255), 'responsibility' VARCHAR(255), 'ia_controls' VARCHAR(255), 'check__system' VARCHAR(255) NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' VARCHAR(255) NOT NULL, 'check_check_content_ref__href' VARCHAR(255) NOT NULL, 'fix__id' VARCHAR(255) NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' VARCHAR(255) NOT NULL, 'reference__dc_identifier' VARCHAR(255) NOT NULL, 'reference__dc_publisher' VARCHAR(255) NOT NULL, 'reference__dc_subject' VARCHAR(255) NOT NULL, 'reference__dc_title' VARCHAR(255) NOT NULL, 'reference__dc_type' VARCHAR(255) NOT NULL, 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL);`,
+      `CREATE TABLE 'StigData' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' TEXT NOT NULL, 'group_title' TEXT NOT NULL, 'description' TEXT NOT NULL, 'rule_id' TEXT NOT NULL UNIQUE, 'severity' TEXT, 'weight' TEXT NOT NULL, 'rule_ver' TEXT NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' TEXT, 'false_negatives' TEXT, 'documentable' TEXT NOT NULL, 'mitigations' TEXT, 'security_override_guidance' TEXT, 'potential_impact' TEXT, 'third_party_tools' TEXT, 'mitigation_control' TEXT, 'responsibility' TEXT, 'ia_controls' TEXT, 'check__system' TEXT NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' TEXT NOT NULL, 'check_check_content_ref__href' TEXT NOT NULL, 'fix__id' TEXT NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' TEXT NOT NULL, 'reference__dc_identifier' TEXT NOT NULL, 'reference__dc_publisher' TEXT NOT NULL, 'reference__dc_subject' TEXT NOT NULL, 'reference__dc_title' TEXT NOT NULL, 'reference__dc_type' TEXT NOT NULL, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL);`,
     );
     await sequelize.query(
       "INSERT INTO `StigData` SELECT `id`, `vuln_num`, `group_title`, `description`, `rule_id`, `severity`, `weight`, `rule_ver`, `rule_title`, `vuln_discuss`, `false_positives`, `false_negatives`, `documentable`, `mitigations`, `security_override_guidance`, `potential_impact`, `third_party_tools`, `mitigation_control`, `responsibility`, `ia_controls`, `check__system`, `check_check_content`, `check_check_content_ref__name`, `check_check_content_ref__href`, `fix__id`, `fixtext`, `fixtext__fixref`, `reference__dc_identifier`, `reference__dc_publisher`, `reference__dc_subject`, `reference__dc_title`, `reference__dc_type`, `lastUpdate`, `creationDate` FROM `StigData_backup`;",

--- a/db/migrations/2024.01.08T05.54.40.StigReferences.js
+++ b/db/migrations/2024.01.08T05.54.40.StigReferences.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   if (sequelize.getDialect() === "sqlite") {
     await sequelize.query(
       `CREATE TABLE 'StigData_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'vuln_num' TEXT NOT NULL, 'group_title' TEXT NOT NULL, 'description' TEXT NOT NULL, 'rule_id' TEXT NOT NULL UNIQUE, 'severity' TEXT, 'weight' TEXT NOT NULL, 'rule_ver' TEXT NOT NULL, 'rule_title' TEXT NOT NULL, 'vuln_discuss' TEXT NOT NULL, 'false_positives' TEXT, 'false_negatives' TEXT, 'documentable' TEXT NOT NULL, 'mitigations' TEXT, 'security_override_guidance' TEXT, 'potential_impact' TEXT, 'third_party_tools' TEXT, 'mitigation_control' TEXT, 'responsibility' TEXT, 'ia_controls' TEXT, 'check__system' TEXT NOT NULL, 'check_check_content' TEXT NOT NULL, 'check_check_content_ref__name' TEXT NOT NULL, 'check_check_content_ref__href' TEXT NOT NULL, 'fix__id' TEXT NOT NULL, 'fixtext' TEXT NOT NULL, 'fixtext__fixref' TEXT NOT NULL, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL);`,
@@ -83,7 +82,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().addColumn("StigData", "reference__dc_identifier", {
       type: DataTypes.TEXT,

--- a/db/migrations/2024.01.13T21.51.56.Theme.js
+++ b/db/migrations/2024.01.13T21.51.56.Theme.js
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 dotenv.config();
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Themes", {
@@ -11,15 +11,15 @@ export const up = async () => {
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -38,14 +38,14 @@ export const down = async () => {
     await sequelize.getQueryInterface().removeColumn("Users", "ThemeId");
   } else {
     await sequelize.query(
-      `CREATE TABLE IF NOT EXISTS 'Users_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' VARCHAR(255) NOT NULL, 'lastName' VARCHAR(255) NOT NULL, 'email' VARCHAR(255) NOT NULL UNIQUE, 'password' VARCHAR(128), 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
+      `CREATE TABLE IF NOT EXISTS 'Users_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' TEXT NOT NULL, 'lastName' TEXT NOT NULL, 'email' TEXT NOT NULL UNIQUE, 'password' TEXT, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `Users_backup` SELECT `id`, `firstName`, `lastName`, `email`, `password`, `lastUpdate`, `creationDate`, `UserRoleId`, `TimezoneId` FROM `Users`;",
     );
     await sequelize.query("DROP TABLE `Users`;");
     await sequelize.query(
-      `CREATE TABLE IF NOT EXISTS 'Users' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' VARCHAR(255) NOT NULL, 'lastName' VARCHAR(255) NOT NULL, 'email' VARCHAR(255) NOT NULL UNIQUE, 'password' VARCHAR(128), 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
+      `CREATE TABLE IF NOT EXISTS 'Users' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' TEXT NOT NULL, 'lastName' TEXT NOT NULL, 'email' TEXT NOT NULL UNIQUE, 'password' TEXT, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `Users` SELECT `id`, `firstName`, `lastName`, `email`, `password`, `lastUpdate`, `creationDate`, `UserRoleId`, `TimezoneId` FROM `Users_backup`;",

--- a/db/migrations/2024.01.13T21.51.56.Theme.js
+++ b/db/migrations/2024.01.13T21.51.56.Theme.js
@@ -1,9 +1,8 @@
 import * as dotenv from "dotenv";
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
 dotenv.config();
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Themes", {
     id: {
       type: DataTypes.INTEGER,
@@ -33,7 +32,7 @@ export const up = async () => {
     onDelete: "SET NULL",
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().removeColumn("Users", "ThemeId");
   } else {

--- a/db/migrations/2024.01.15T18.50.20.Tokens.js
+++ b/db/migrations/2024.01.15T18.50.20.Tokens.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Tokens", {
     id: {
       type: DataTypes.INTEGER,
@@ -39,6 +38,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Tokens");
 };

--- a/db/migrations/2024.01.15T18.50.20.Tokens.js
+++ b/db/migrations/2024.01.15T18.50.20.Tokens.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Tokens", {
     id: {
@@ -9,23 +9,23 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING(),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     token: {
-      type: DataTypes.STRING(),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     UserId: {

--- a/db/migrations/2024.01.23T16.40.30.Cci.js
+++ b/db/migrations/2024.01.23T16.40.30.Cci.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("CciLists", {
     id: {
@@ -10,11 +10,11 @@ export const up = async () => {
       autoIncrement: true,
     },
     version: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     publishdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     importComplete: {
@@ -22,11 +22,11 @@ export const up = async () => {
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -38,7 +38,7 @@ export const up = async () => {
       autoIncrement: true,
     },
     cciId: {
-      type: DataTypes.STRING(10),
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -47,15 +47,15 @@ export const up = async () => {
       allowNull: false,
     },
     publishdate: {
-      type: DataTypes.STRING(25),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     contributor: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     definition: {
-      type: DataTypes.STRING(1024),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     typePolicy: {
@@ -67,11 +67,11 @@ export const up = async () => {
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     CciListId: {
@@ -93,21 +93,21 @@ export const up = async () => {
       autoIncrement: true,
     },
     title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: "TitleVersion",
     },
     version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: "TitleVersion",
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -122,23 +122,23 @@ export const up = async () => {
       autoIncrement: true,
     },
     creator: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     location: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     index: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     PolicyDocumentId: {
@@ -195,14 +195,14 @@ export const down = async () => {
     await sequelize.getQueryInterface().removeColumn("Boundaries", "PolicyDocumentId");
   } else {
     await sequelize.query(
-      `CREATE TABLE 'Boundaries_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'name' VARCHAR(255) NOT NULL UNIQUE, 'lastUpdate' VARCHAR(29) NOT NULL, 'creationDate' VARCHAR(29) NOT NULL, 'ownerId' INTEGER REFERENCES 'Users' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TierId' INTEGER NOT NULL REFERENCES 'Tiers' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigLibraryId' INTEGER REFERENCES 'StigLibraries' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
+      `CREATE TABLE 'Boundaries_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'name' TEXT NOT NULL UNIQUE, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'ownerId' INTEGER REFERENCES 'Users' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TierId' INTEGER NOT NULL REFERENCES 'Tiers' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigLibraryId' INTEGER REFERENCES 'StigLibraries' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `Boundaries_backup` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId`, `StigLibraryId` FROM `Boundaries`;",
     );
     await sequelize.query("DROP TABLE `Boundaries`;");
     await sequelize.query(
-      `CREATE TABLE 'Boundaries' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'name' VARCHAR(255) NOT NULL UNIQUE, 'lastUpdate' VARCHAR(29) NOT NULL, 'creationDate' VARCHAR(29) NOT NULL, 'ownerId' INTEGER REFERENCES 'Users' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TierId' INTEGER NOT NULL REFERENCES 'Tiers' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigLibraryId' INTEGER REFERENCES 'StigLibraries' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
+      `CREATE TABLE 'Boundaries' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'name' TEXT NOT NULL UNIQUE, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'ownerId' INTEGER REFERENCES 'Users' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'TierId' INTEGER NOT NULL REFERENCES 'Tiers' ('id') ON DELETE CASCADE ON UPDATE CASCADE, 'StigLibraryId' INTEGER REFERENCES 'StigLibraries' ('id') ON DELETE RESTRICT ON UPDATE CASCADE);`,
     );
     await sequelize.query(
       "INSERT INTO `Boundaries` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId`, `StigLibraryId` FROM `Boundaries_backup`;",

--- a/db/migrations/2024.01.23T16.40.30.Cci.js
+++ b/db/migrations/2024.01.23T16.40.30.Cci.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("CciLists", {
     id: {
       type: DataTypes.INTEGER,
@@ -185,7 +184,7 @@ export const up = async () => {
     onDelete: "RESTRICT",
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("CciItem_CciReferences");
   await sequelize.getQueryInterface().dropTable("CciReferences");
   await sequelize.getQueryInterface().dropTable("PolicyDocuments");

--- a/db/migrations/2024.01.29T20.18.23.StigIdent.js
+++ b/db/migrations/2024.01.29T20.18.23.StigIdent.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("StigIdents", {
     id: {
       type: DataTypes.INTEGER,
@@ -43,7 +42,7 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("StigData_StigIdents");
   await sequelize.getQueryInterface().dropTable("StigIdents");
 };

--- a/db/migrations/2024.01.29T20.18.23.StigIdent.js
+++ b/db/migrations/2024.01.29T20.18.23.StigIdent.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("StigIdents", {
     id: {
@@ -10,19 +10,19 @@ export const up = async () => {
       autoIncrement: true,
     },
     system: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     text: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.02.02T21.20.55.Classification.js
+++ b/db/migrations/2024.02.02T21.20.55.Classification.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Classifications", {
     id: {
@@ -10,23 +10,23 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING(50),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     abbreviation: {
-      type: DataTypes.STRING(5),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     color: {
-      type: DataTypes.STRING(6),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -40,7 +40,7 @@ export const up = async () => {
     onDelete: "RESTRICT",
   });
   await sequelize.getQueryInterface().addColumn("Boundaries", "caveats", {
-    type: DataTypes.STRING(50),
+    type: DataTypes.TEXT,
     allowNull: true,
   });
 };
@@ -50,14 +50,14 @@ export const down = async () => {
     await sequelize.getQueryInterface().removeColumn("Boundaries", "caveats");
   } else {
     await sequelize.query(
-      "CREATE TABLE `Boundaries_backup` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255) NOT NULL UNIQUE, `lastUpdate` VARCHAR(29) NOT NULL, `creationDate` VARCHAR(29) NOT NULL, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, `StigLibraryId` INTEGER REFERENCES `StigLibraries` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, `PolicyDocumentId` INTEGER NOT NULL REFERENCES `PolicyDocuments` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE);",
+      "CREATE TABLE `Boundaries_backup` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL UNIQUE, `lastUpdate` TEXT NOT NULL, `creationDate` TEXT NOT NULL, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, `StigLibraryId` INTEGER REFERENCES `StigLibraries` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, `PolicyDocumentId` INTEGER NOT NULL REFERENCES `PolicyDocuments` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Boundaries_backup` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId`, `StigLibraryId`, `PolicyDocumentId` FROM `Boundaries`;",
     );
     await sequelize.query("DROP TABLE `Boundaries`;");
     await sequelize.query(
-      "CREATE TABLE `Boundaries` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255) NOT NULL UNIQUE, `lastUpdate` VARCHAR(29) NOT NULL, `creationDate` VARCHAR(29) NOT NULL, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, `StigLibraryId` INTEGER REFERENCES `StigLibraries` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, `PolicyDocumentId` INTEGER NOT NULL REFERENCES `PolicyDocuments` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE);",
+      "CREATE TABLE `Boundaries` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL UNIQUE, `lastUpdate` TEXT NOT NULL, `creationDate` TEXT NOT NULL, `ownerId` INTEGER REFERENCES `Users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE, `TierId` INTEGER NOT NULL REFERENCES `Tiers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, `StigLibraryId` INTEGER REFERENCES `StigLibraries` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE, `PolicyDocumentId` INTEGER NOT NULL REFERENCES `PolicyDocuments` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE);",
     );
     await sequelize.query(
       "INSERT INTO `Boundaries` SELECT `id`, `name`, `lastUpdate`, `creationDate`, `ownerId`, `TierId`, `StigLibraryId`, `PolicyDocumentId` FROM `Boundaries_backup`;",

--- a/db/migrations/2024.02.02T21.20.55.Classification.js
+++ b/db/migrations/2024.02.02T21.20.55.Classification.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Classifications", {
     id: {
       type: DataTypes.INTEGER,
@@ -44,7 +43,7 @@ export const up = async () => {
     allowNull: true,
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize.getQueryInterface().removeColumn("Boundaries", "ClassificationId");
     await sequelize.getQueryInterface().removeColumn("Boundaries", "caveats");

--- a/db/migrations/2024.03.12T20.57.57.StigAliases.js
+++ b/db/migrations/2024.03.12T20.57.57.StigAliases.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("StigAliases", {
     id: {
       type: DataTypes.INTEGER,
@@ -27,6 +26,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("StigAliases");
 };

--- a/db/migrations/2024.03.12T20.57.57.StigAliases.js
+++ b/db/migrations/2024.03.12T20.57.57.StigAliases.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("StigAliases", {
     id: {
@@ -10,19 +10,19 @@ export const up = async () => {
       autoIncrement: true,
     },
     alias: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     identifier: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.03.12T23.10.26.TirAliases.js
+++ b/db/migrations/2024.03.12T23.10.26.TirAliases.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("TirAliases", {
     id: {
       type: DataTypes.INTEGER,
@@ -26,6 +25,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("TirAliases");
 };

--- a/db/migrations/2024.03.12T23.10.26.TirAliases.js
+++ b/db/migrations/2024.03.12T23.10.26.TirAliases.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("TirAliases", {
     id: {
@@ -9,19 +9,19 @@ export const up = async () => {
       autoIncrement: true,
     },
     term: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     alias: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.03.13T17.15.25.AssessmentUpdate.js
+++ b/db/migrations/2024.03.13T17.15.25.AssessmentUpdate.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().addColumn("Assessments", "succeededByAssessmentId", {
     type: DataTypes.INTEGER,
     allowNull: true,
@@ -14,6 +13,6 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().removeColumn("Assessments", "succeededByAssessmentId");
 };

--- a/db/migrations/2024.03.28T03.47.39.UserUpdate.js
+++ b/db/migrations/2024.03.28T03.47.39.UserUpdate.js
@@ -1,6 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
   await sequelize.getQueryInterface().addColumn(
     "Users",
@@ -70,7 +69,7 @@ export const up = async () => {
   );
   await upMigration.commit();
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
   if (sequelize.getDialect() !== "sqlite") {
     await sequelize

--- a/db/migrations/2024.03.28T03.47.39.UserUpdate.js
+++ b/db/migrations/2024.03.28T03.47.39.UserUpdate.js
@@ -1,12 +1,12 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   const upMigration = await sequelize.transaction();
   await sequelize.getQueryInterface().addColumn(
     "Users",
     "organization",
     {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     { transaction: upMigration },
@@ -15,7 +15,7 @@ export const up = async () => {
     "Users",
     "passwordChangedAt",
     {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     { transaction: upMigration },
@@ -44,7 +44,7 @@ export const up = async () => {
     "Users",
     "lastLogin",
     {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     { transaction: upMigration },
@@ -53,7 +53,7 @@ export const up = async () => {
     "Users",
     "creationMethod",
     {
-      type: DataTypes.STRING(16),
+      type: DataTypes.TEXT,
       allowNull: false,
       defaultValue: "local",
     },
@@ -63,7 +63,7 @@ export const up = async () => {
     "Users",
     "salt",
     {
-      type: DataTypes.STRING(32),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     { transaction: upMigration },
@@ -97,7 +97,7 @@ export const down = async () => {
     await downMigration.commit();
   } else {
     await sequelize.query(
-      `CREATE TABLE 'Users_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' VARCHAR(255) NOT NULL, 'lastName' VARCHAR(255) NOT NULL, 'email' VARCHAR(255) NOT NULL UNIQUE, 'password' VARCHAR(128), 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'ThemeId' INTEGER REFERENCES 'Themes' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
+      `CREATE TABLE 'Users_backup' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' TEXT NOT NULL, 'lastName' TEXT NOT NULL, 'email' TEXT NOT NULL UNIQUE, 'password' TEXT, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'ThemeId' INTEGER REFERENCES 'Themes' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
       { transaction: downMigration },
     );
     await sequelize.query(
@@ -106,7 +106,7 @@ export const down = async () => {
     );
     await sequelize.query(`DROP TABLE 'Users';`, { transaction: downMigration });
     await sequelize.query(
-      `CREATE TABLE 'Users' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' VARCHAR(255) NOT NULL, 'lastName' VARCHAR(255) NOT NULL, 'email' VARCHAR(255) NOT NULL UNIQUE, 'password' VARCHAR(128), 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'lastUpdate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'creationDate' VARCHAR(${DATETIME_LENGTH}) NOT NULL, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'ThemeId' INTEGER REFERENCES 'Themes' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
+      `CREATE TABLE 'Users' ('id' INTEGER PRIMARY KEY AUTOINCREMENT, 'firstName' TEXT NOT NULL, 'lastName' TEXT NOT NULL, 'email' TEXT NOT NULL UNIQUE, 'password' TEXT, 'UserRoleId' INTEGER REFERENCES 'UserRoles' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'lastUpdate' TEXT NOT NULL, 'creationDate' TEXT NOT NULL, 'TimezoneId' INTEGER REFERENCES 'Timezones' ('id') ON DELETE SET NULL ON UPDATE CASCADE, 'ThemeId' INTEGER REFERENCES 'Themes' ('id') ON DELETE SET NULL ON UPDATE CASCADE);`,
       { transaction: downMigration },
     );
     await sequelize.query(

--- a/db/migrations/2024.03.28T15.42.10.EvalDates_User.js
+++ b/db/migrations/2024.03.28T15.42.10.EvalDates_User.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("EvalDates_Users", {
     UserId: {
       type: DataTypes.INTEGER,
@@ -26,6 +25,6 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("EvalDates_Users");
 };

--- a/db/migrations/2024.03.28T19.15.44.MilestoneDates_User.js
+++ b/db/migrations/2024.03.28T19.15.44.MilestoneDates_User.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("MilestoneDates_Users", {
     UserId: {
       type: DataTypes.INTEGER,
@@ -26,6 +25,6 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("MilestoneDates_Users");
 };

--- a/db/migrations/2024.04.30T15.26.43.SystemInfoUpdate.js
+++ b/db/migrations/2024.04.30T15.26.43.SystemInfoUpdate.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const transaction = await sequelize.transaction();
   try {
     if (sequelize.getDialect() === "postgres") {
@@ -212,7 +211,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   try {
     if (sequelize.getDialect() === "sqlite") {
       await sequelize.query(`PRAGMA foreign_keys = OFF;`);

--- a/db/migrations/2024.07.22T14.52.19.Protocols.js
+++ b/db/migrations/2024.07.22T14.52.19.Protocols.js
@@ -10,15 +10,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.22T14.52.19.Protocols.js
+++ b/db/migrations/2024.07.22T14.52.19.Protocols.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Protocols", {
     id: {
       type: DataTypes.INTEGER,
@@ -24,6 +23,6 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Protocols");
 };

--- a/db/migrations/2024.07.24T18.13.41.Cpe.js
+++ b/db/migrations/2024.07.24T18.13.41.Cpe.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("CpeParts", {
     id: {
       type: DataTypes.INTEGER,
@@ -100,7 +99,7 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("cpeParts");
   await sequelize.getQueryInterface().dropTable("CpeVendors");
   await sequelize.getQueryInterface().dropTable("CpeProducts");

--- a/db/migrations/2024.07.24T18.13.41.Cpe.js
+++ b/db/migrations/2024.07.24T18.13.41.Cpe.js
@@ -10,19 +10,19 @@ export const up = async () => {
       autoIncrement: true,
     },
     partCode: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     partDefinition: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -34,15 +34,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     cpeVendorString: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -54,15 +54,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     cpeProductString: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.25T14.52.12.Cve.js
+++ b/db/migrations/2024.07.25T14.52.12.Cve.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Cves", {
     id: {
       type: DataTypes.INTEGER,
@@ -102,7 +101,7 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Cve_Systems");
   await sequelize.getQueryInterface().dropTable("Cves");
   if (sequelize.getDialect() === "postgres") {

--- a/db/migrations/2024.07.25T14.52.12.Cve.js
+++ b/db/migrations/2024.07.25T14.52.12.Cve.js
@@ -10,7 +10,7 @@ export const up = async () => {
       autoIncrement: true,
     },
     cveId: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     cvss3AttackComplexity: {
@@ -46,7 +46,7 @@ export const up = async () => {
       values: ["NONE", "REQUIRED"],
     },
     cvss3Version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     // cvss3BaseSeverity: {
     //   type: DataTypes.ENUM,
@@ -58,7 +58,7 @@ export const up = async () => {
     //   type: DataTypes.INTEGER,
     // },
     // cvss3_vector: {
-    //   type: DataTypes.STRING,
+    //   type: DataTypes.TEXT,
     // },
     // cvssV3_impactScore: {
     //   type: DataTypes.INTEGER,
@@ -67,14 +67,14 @@ export const up = async () => {
     //   type: DataTypes.INTEGER,
     // },
     // cvss_vector: {
-    //   type: DataTypes.STRING,
+    //   type: DataTypes.TEXT,
     // },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.34.15.NessusPluginFamily.js
+++ b/db/migrations/2024.07.31T02.34.15.NessusPluginFamily.js
@@ -10,15 +10,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.34.15.NessusPluginFamily.js
+++ b/db/migrations/2024.07.31T02.34.15.NessusPluginFamily.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusPluginFamilies", {
     id: {
       type: DataTypes.INTEGER,
@@ -24,6 +23,6 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusPluginFamilies");
 };

--- a/db/migrations/2024.07.31T02.35.42.NessusPlugin.js
+++ b/db/migrations/2024.07.31T02.35.42.NessusPlugin.js
@@ -1,5 +1,4 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
 const NessusPluginTypes = {
   Combined: "combined",
@@ -8,7 +7,7 @@ const NessusPluginTypes = {
   Summary: "summary",
 };
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusPlugins", {
     id: {
       type: DataTypes.INTEGER,
@@ -108,7 +107,7 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Cve_NessusPlugins");
   await sequelize.getQueryInterface().dropTable("NessusPlugins");
 };

--- a/db/migrations/2024.07.31T02.35.42.NessusPlugin.js
+++ b/db/migrations/2024.07.31T02.35.42.NessusPlugin.js
@@ -21,22 +21,22 @@ export const up = async () => {
       allowNull: false,
     },
     pluginPublicationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     pluginModificationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     pluginName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     scriptVersion: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     severity: {
@@ -62,7 +62,7 @@ export const up = async () => {
       allowNull: false,
     },
     synopsis: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     NessusPluginFamilyId: {
@@ -76,11 +76,11 @@ export const up = async () => {
       onUpdate: "CASCADE",
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.36.21.NessusServiceName.js
+++ b/db/migrations/2024.07.31T02.36.21.NessusServiceName.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusServiceNames", {
     id: {
       type: DataTypes.INTEGER,
@@ -23,6 +22,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusServiceNames");
 };

--- a/db/migrations/2024.07.31T02.36.21.NessusServiceName.js
+++ b/db/migrations/2024.07.31T02.36.21.NessusServiceName.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NessusServiceNames", {
     id: {
@@ -10,15 +10,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.37.52.NessusReport.js
+++ b/db/migrations/2024.07.31T02.37.52.NessusReport.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NessusReports", {
     id: {
@@ -10,15 +10,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reportHostName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     hash: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {
@@ -32,11 +32,11 @@ export const up = async () => {
       onDelete: "CASCADE",
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.37.52.NessusReport.js
+++ b/db/migrations/2024.07.31T02.37.52.NessusReport.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusReports", {
     id: {
       type: DataTypes.INTEGER,
@@ -41,6 +40,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusReports");
 };

--- a/db/migrations/2024.07.31T02.38.35.NessusReportItem.js
+++ b/db/migrations/2024.07.31T02.38.35.NessusReportItem.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusReportItems", {
     id: {
       type: DataTypes.INTEGER,
@@ -126,6 +125,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusReportItems");
 };

--- a/db/migrations/2024.07.31T02.38.35.NessusReportItem.js
+++ b/db/migrations/2024.07.31T02.38.35.NessusReportItem.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NessusReportItems", {
     id: {
@@ -14,37 +14,37 @@ export const up = async () => {
       allowNull: false,
     },
     ageOfVuln: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cisaKnownExploited: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     agent: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     alwaysRun: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetCategories: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetInventory: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetInventoryCategory: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     bid: {
       type: DataTypes.INTEGER,
     },
     cvss3TemporalVector: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cvss3TemporalScore: {
       type: DataTypes.DECIMAL(3, 1),
     },
     cvssTemporalVector: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cvssTemporalScore: {
       type: DataTypes.DECIMAL(3, 1),
@@ -53,10 +53,10 @@ export const up = async () => {
       type: DataTypes.INTEGER,
     },
     canvasPackage: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     ceaId: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     pluginOutput: {
       type: DataTypes.TEXT,
@@ -65,7 +65,7 @@ export const up = async () => {
       type: DataTypes.INTEGER,
     },
     severityOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     statusOverride: {
       type: DataTypes.ENUM,
@@ -73,7 +73,7 @@ export const up = async () => {
       values: ["Not_Reviewed", "Open", "NotAFinding", "Not_Applicable"],
     },
     statusOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     NessusPluginId: {
       type: DataTypes.INTEGER,
@@ -117,11 +117,11 @@ export const up = async () => {
       },
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.07.31T02.39.19.NessusOverride.js
+++ b/db/migrations/2024.07.31T02.39.19.NessusOverride.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NessusOverrides", {
     id: {
@@ -10,19 +10,19 @@ export const up = async () => {
       allowNull: false,
     },
     type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {

--- a/db/migrations/2024.07.31T02.39.19.NessusOverride.js
+++ b/db/migrations/2024.07.31T02.39.19.NessusOverride.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusOverrides", {
     id: {
       type: DataTypes.INTEGER,
@@ -45,6 +44,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusOverrides");
 };

--- a/db/migrations/2024.07.31T02.40.27.CveOverride.js
+++ b/db/migrations/2024.07.31T02.40.27.CveOverride.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("CveOverrides", {
     id: {
@@ -15,11 +15,11 @@ export const up = async () => {
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {

--- a/db/migrations/2024.07.31T02.40.27.CveOverride.js
+++ b/db/migrations/2024.07.31T02.40.27.CveOverride.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("CveOverrides", {
     id: {
       type: DataTypes.INTEGER,
@@ -42,6 +41,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("CveOverrides");
 };

--- a/db/migrations/2024.08.16T04.39.52.TirConfig.js
+++ b/db/migrations/2024.08.16T04.39.52.TirConfig.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("TirConfigs", {
     id: {
       type: DataTypes.INTEGER,
@@ -28,6 +27,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("TirConfigs");
 };

--- a/db/migrations/2024.08.16T04.39.52.TirConfig.js
+++ b/db/migrations/2024.08.16T04.39.52.TirConfig.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("TirConfigs", {
     id: {
@@ -10,20 +10,20 @@ export const up = async () => {
       autoIncrement: true,
     },
     key: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.08.19T05.09.27.NessusPlugin_Boundary.js
+++ b/db/migrations/2024.08.19T05.09.27.NessusPlugin_Boundary.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NessusPlugin_Boundaries", {
     NessusPluginId: {

--- a/db/migrations/2024.08.19T05.09.27.NessusPlugin_Boundary.js
+++ b/db/migrations/2024.08.19T05.09.27.NessusPlugin_Boundary.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NessusPlugin_Boundaries", {
     NessusPluginId: {
       type: DataTypes.INTEGER,
@@ -34,6 +33,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("NessusPlugin_Boundaries");
 };

--- a/db/migrations/2024.08.24T00.29.54.MilestoneFix.js
+++ b/db/migrations/2024.08.24T00.29.54.MilestoneFix.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().dropTable("EvaluationItem_Milestones");
 };

--- a/db/migrations/2024.08.24T00.29.54.MilestoneFix.js
+++ b/db/migrations/2024.08.24T00.29.54.MilestoneFix.js
@@ -1,10 +1,9 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("EvaluationItem_Milestones");
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("EvaluationItem_Milestones", {
     EvaluationItemId: {
       type: DataTypes.INTEGER,

--- a/db/migrations/2024.10.06T08.32.02.StigOverride.js
+++ b/db/migrations/2024.10.06T08.32.02.StigOverride.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 export const up = async () => {
   const schemaPrefix = sequelize.getDialect() === "postgres" ? "public." : "";
   await sequelize.getQueryInterface().createTable("StigOverrides", {
@@ -11,19 +11,19 @@ export const up = async () => {
       allowNull: false,
     },
     type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     SystemId: {

--- a/db/migrations/2024.10.06T08.32.02.StigOverride.js
+++ b/db/migrations/2024.10.06T08.32.02.StigOverride.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
 
-import { sequelize } from "../umzug.js";
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const schemaPrefix = sequelize.getDialect() === "postgres" ? "public." : "";
   await sequelize.getQueryInterface().createTable("StigOverrides", {
     id: {
@@ -59,6 +58,6 @@ export const up = async () => {
     FROM ${schemaPrefix}"Overrides"
     `);
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("StigOverrides");
 };

--- a/db/migrations/2024.10.07T01.24.44.AssessmentItemUpdate.js
+++ b/db/migrations/2024.10.07T01.24.44.AssessmentItemUpdate.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const transaction = await sequelize.transaction();
   try {
     if (sequelize.getDialect() === "postgres") {
@@ -75,7 +74,7 @@ export const up = async () => {
     throw error;
   }
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const transaction = await sequelize.transaction();
   try {
     if (sequelize.getDialect() === "postgres") {

--- a/db/migrations/2024.10.07T01.24.44.AssessmentItemUpdate.js
+++ b/db/migrations/2024.10.07T01.24.44.AssessmentItemUpdate.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 
 export const up = async () => {
   const transaction = await sequelize.transaction();
@@ -54,7 +54,7 @@ export const up = async () => {
       "AssessmentItems",
       "statusOverride",
       {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         allowNull: true,
       },
       { transaction },
@@ -63,7 +63,7 @@ export const up = async () => {
       "AssessmentItems",
       "statusOverrideJustification",
       {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         allowNull: true,
       },
       { transaction },

--- a/db/migrations/2024.12.03T16.08.21.TirNotifications.js
+++ b/db/migrations/2024.12.03T16.08.21.TirNotifications.js
@@ -1,5 +1,5 @@
 import { DataTypes } from "sequelize";
-import { sequelize, DATETIME_LENGTH } from "../umzug.js";
+import { sequelize } from "../umzug.js";
 
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("NotificationCategories", {
@@ -11,15 +11,15 @@ export const up = async () => {
       autoIncrement: true,
     },
     category: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });
@@ -42,22 +42,22 @@ export const up = async () => {
       onDelete: "CASCADE",
     },
     message: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
 
     dueDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     daysLeft: {
       type: DataTypes.INTEGER,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/migrations/2024.12.03T16.08.21.TirNotifications.js
+++ b/db/migrations/2024.12.03T16.08.21.TirNotifications.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("NotificationCategories", {
     id: {
       type: DataTypes.INTEGER,
@@ -89,7 +88,7 @@ export const up = async () => {
   });
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("TirNotifications_Users");
   await sequelize.getQueryInterface().dropTable("TirNotifications");
   await sequelize.getQueryInterface().dropTable("NotificationCategories");

--- a/db/migrations/2025.02.24T08.17.01.Session.js
+++ b/db/migrations/2025.02.24T08.17.01.Session.js
@@ -4,36 +4,36 @@ import { sequelize } from "../umzug.js";
 export const up = async () => {
   await sequelize.getQueryInterface().createTable("Sessions", {
     id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       primaryKey: true,
     },
     expiresAt: {
-      type: DataTypes.STRING, // Store as ISO string
+      type: DataTypes.TEXT, // Store as ISO string
       allowNull: false,
     },
     authMethod: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     ipAddress: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     userAgent: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     loginTime: {
-      type: DataTypes.STRING, // Store as ISO string
+      type: DataTypes.TEXT, // Store as ISO string
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     UserId: {

--- a/db/migrations/2025.02.24T08.17.01.Session.js
+++ b/db/migrations/2025.02.24T08.17.01.Session.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().createTable("Sessions", {
     id: {
       type: DataTypes.TEXT,
@@ -46,6 +45,6 @@ export const up = async () => {
     },
   });
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   await sequelize.getQueryInterface().dropTable("Sessions");
 };

--- a/db/migrations/2025.03.05T03.08.30.UserProviderUpdate.js
+++ b/db/migrations/2025.03.05T03.08.30.UserProviderUpdate.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
   try {
     await sequelize.getQueryInterface().addColumn(
@@ -20,7 +19,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
   try {
     if (sequelize.getDialect() !== "sqlite") {

--- a/db/migrations/2025.03.31T18.53.57.EvaluationItemUpdate.js
+++ b/db/migrations/2025.03.31T18.53.57.EvaluationItemUpdate.js
@@ -129,21 +129,21 @@ export const down = async () => {
       await sequelize.query(
         `CREATE TABLE IF NOT EXISTS 'EvaluationItems_backup' (
           'id' INTEGER PRIMARY KEY AUTOINCREMENT,
-          'Office_Org' VARCHAR(256),
-          'Resources_Required' VARCHAR(256),
+          'Office_Org' TEXT,
+          'Resources_Required' TEXT,
           'Scheduled_Completion_Date' DATETIME,
-          'Milestone_Changes' VARCHAR(256),
-          'Poam_Comments' VARCHAR(1024),
-          'Mitigations' VARCHAR(256),
+          'Milestone_Changes' TEXT,
+          'Poam_Comments' TEXT,
+          'Mitigations' TEXT,
           'Severity' TEXT,
           'Relevance_of_Threat' TEXT,
           'Likelihood' TEXT,
           'Impact' TEXT,
-          'Impact_Description' VARCHAR(256),
+          'Impact_Description' TEXT,
           'Residual_Risk_Level' TEXT,
-          'Recommendations' VARCHAR(256),
-          'lastUpdate' VARCHAR(29) NOT NULL,
-          'creationDate' VARCHAR(29) NOT NULL,
+          'Recommendations' TEXT,
+          'lastUpdate' TEXT NOT NULL,
+          'creationDate' TEXT NOT NULL,
           'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE,
           'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE
         );`,
@@ -166,21 +166,21 @@ export const down = async () => {
       await sequelize.query(
         `CREATE TABLE IF NOT EXISTS 'EvaluationItems' (
           'id' INTEGER PRIMARY KEY AUTOINCREMENT,
-          'Office_Org' VARCHAR(256),
-          'Resources_Required' VARCHAR(256),
+          'Office_Org' TEXT,
+          'Resources_Required' TEXT,
           'Scheduled_Completion_Date' DATETIME,
-          'Milestone_Changes' VARCHAR(256),
-          'Poam_Comments' VARCHAR(1024),
-          'Mitigations' VARCHAR(256),
+          'Milestone_Changes' TEXT,
+          'Poam_Comments' TEXT,
+          'Mitigations' TEXT,
           'Severity' TEXT,
           'Relevance_of_Threat' TEXT,
           'Likelihood' TEXT,
           'Impact' TEXT,
-          'Impact_Description' VARCHAR(256),
+          'Impact_Description' TEXT,
           'Residual_Risk_Level' TEXT,
-          'Recommendations' VARCHAR(256),
-          'lastUpdate' VARCHAR(29) NOT NULL,
-          'creationDate' VARCHAR(29) NOT NULL,
+          'Recommendations' TEXT,
+          'lastUpdate' TEXT NOT NULL,
+          'creationDate' TEXT NOT NULL,
           'EvaluationId' INTEGER REFERENCES 'Evaluations' ('id') ON DELETE CASCADE ON UPDATE CASCADE,
           'StigDatumId' INTEGER REFERENCES 'StigData' ('id') ON DELETE RESTRICT ON UPDATE CASCADE
         );`,
@@ -204,28 +204,28 @@ export const down = async () => {
         "EvaluationItems",
         "Scheduled_Completion_Date",
         {
-          type: "VARCHAR(29)",
+          type: "TEXT",
         },
         { transaction },
       );
 
-      const varcharCols = {
-        Office_Org: 256,
-        Resources_Required: 256,
-        Milestone_Changes: 256,
-        Poam_Comments: 1024,
-        Mitigations: 256,
-        Impact_Description: 256,
-        Recommendations: 256,
-        lastUpdate: 29,
-        creationDate: 29,
-      };
+      const textCols = [
+        "Office_Org",
+        "Resources_Required",
+        "Milestone_Changes",
+        "Poam_Comments",
+        "Mitigations",
+        "Impact_Description",
+        "Recommendations",
+        "lastUpdate",
+        "creationDate",
+      ];
 
-      for (const [col, len] of Object.entries(varcharCols)) {
+      for (const col of textCols) {
         await queryInterface.changeColumn(
           "EvaluationItems",
           col,
-          { type: `VARCHAR(${len})` },
+          { type: "TEXT" },
           { transaction },
         );
       }

--- a/db/migrations/2025.03.31T18.53.57.EvaluationItemUpdate.js
+++ b/db/migrations/2025.03.31T18.53.57.EvaluationItemUpdate.js
@@ -1,6 +1,5 @@
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const queryInterface = sequelize.getQueryInterface();
   const dialect = sequelize.getDialect();
   const transaction = await sequelize.transaction();
@@ -119,7 +118,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const queryInterface = sequelize.getQueryInterface();
   const dialect = sequelize.getDialect();
   const transaction = await sequelize.transaction();

--- a/db/migrations/2025.05.05T22.23.27.TirConfigUpdate.js
+++ b/db/migrations/2025.05.05T22.23.27.TirConfigUpdate.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
 
   try {
@@ -49,7 +48,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
 
   try {

--- a/db/migrations/2025.05.05T22.23.27.TirConfigUpdate.js
+++ b/db/migrations/2025.05.05T22.23.27.TirConfigUpdate.js
@@ -58,7 +58,7 @@ export const down = async () => {
         "TirConfigs",
         "value",
         {
-          type: DataTypes.STRING,
+          type: DataTypes.TEXT,
           allowNull: false,
         },
         { transaction: downMigration },

--- a/db/migrations/2025.06.26T18.42.44.Controls.js
+++ b/db/migrations/2025.06.26T18.42.44.Controls.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
   try {
     // ControlNumber table
@@ -680,7 +679,7 @@ export const up = async () => {
     throw error;
   }
 };
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
   try {
     await sequelize.getQueryInterface().dropTable("ControlWithdrawns", {

--- a/db/migrations/2025.07.10T21.02.57.SCTM.js
+++ b/db/migrations/2025.07.10T21.02.57.SCTM.js
@@ -1,7 +1,6 @@
 import { DataTypes } from "sequelize";
-import { sequelize } from "../umzug.js";
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
   try {
     await sequelize.getQueryInterface().createTable(
@@ -241,7 +240,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
   try {
     await sequelize.getQueryInterface().dropTable("ControlRecordItems", {

--- a/db/migrations/2025.10.13T04.24.38.TirConfigRename.js
+++ b/db/migrations/2025.10.13T04.24.38.TirConfigRename.js
@@ -1,4 +1,3 @@
-import { sequelize } from "../umzug.js";
 
 const RENAMES = [
   { from: "auth_enable_local", to: "authLocalEnable" },
@@ -40,7 +39,7 @@ const RENAMES = [
   { from: "notification_timeout", to: "notificationTimeout" },
 ];
 
-export const up = async () => {
+export const up = async ({ context: sequelize }) => {
   const upMigration = await sequelize.transaction();
 
   try {
@@ -56,7 +55,7 @@ export const up = async () => {
   }
 };
 
-export const down = async () => {
+export const down = async ({ context: sequelize }) => {
   const downMigration = await sequelize.transaction();
 
   try {

--- a/db/migrations/2026.07.25T15.13.30.VarcharToText.js
+++ b/db/migrations/2026.07.25T15.13.30.VarcharToText.js
@@ -1,0 +1,28 @@
+export const up = async ({ context: sequelize }) => {
+  if (sequelize.getDialect() !== "postgres") return;
+
+  const [columns] = await sequelize.query(`
+    SELECT table_name, column_name, column_default
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND data_type = 'character varying'
+      AND table_name NOT IN ('SequelizeMeta', 'seeder_meta')
+  `);
+
+  for (const { table_name, column_name, column_default } of columns) {
+    await sequelize.query(
+      `ALTER TABLE "${table_name}" ALTER COLUMN "${column_name}" TYPE TEXT;`,
+    );
+    if (column_default?.includes("::character varying")) {
+      const textDefault = column_default.replaceAll(
+        "::character varying",
+        "::text",
+      );
+      await sequelize.query(
+        `ALTER TABLE "${table_name}" ALTER COLUMN "${column_name}" SET DEFAULT ${textDefault};`,
+      );
+    }
+  }
+};
+
+export const down = async () => {};

--- a/db/models/assessment.ts
+++ b/db/models/assessment.ts
@@ -48,19 +48,19 @@ Assessment.init(
       primaryKey: true,
     },
     classification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     customname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     uuid: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     comment: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     succeededByAssessmentId: {
@@ -72,11 +72,11 @@ Assessment.init(
       },
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/assessmentItem.ts
+++ b/db/models/assessmentItem.ts
@@ -67,14 +67,14 @@ AssessmentItem.init(
       allowNull: true,
     },
     severityOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     statusOverride: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     statusOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     current: {
@@ -89,11 +89,11 @@ AssessmentItem.init(
       },
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/boundary.ts
+++ b/db/models/boundary.ts
@@ -60,20 +60,20 @@ Boundary.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
     caveats: {
-      type: DataTypes.STRING(50),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/boundaryRole.ts
+++ b/db/models/boundaryRole.ts
@@ -27,16 +27,16 @@ BoundaryRole.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cciItem.ts
+++ b/db/models/cciItem.ts
@@ -47,7 +47,7 @@ CciItem.init(
       autoIncrement: true,
     },
     cciId: {
-      type: DataTypes.STRING(10),
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -56,15 +56,15 @@ CciItem.init(
       allowNull: false,
     },
     publishdate: {
-      type: DataTypes.STRING(25),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     contributor: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     definition: {
-      type: DataTypes.STRING(1024),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     typePolicy: {
@@ -76,11 +76,11 @@ CciItem.init(
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cciList.ts
+++ b/db/models/cciList.ts
@@ -25,11 +25,11 @@ CciList.init(
       autoIncrement: true,
     },
     version: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     publishdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     importComplete: {
@@ -37,11 +37,11 @@ CciList.init(
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cciReferences.ts
+++ b/db/models/cciReferences.ts
@@ -36,23 +36,23 @@ CciReference.init(
       autoIncrement: true,
     },
     creator: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     location: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     index: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/classification.ts
+++ b/db/models/classification.ts
@@ -35,23 +35,23 @@ Classification.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING(50),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     abbreviation: {
-      type: DataTypes.STRING(5),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     color: {
-      type: DataTypes.STRING(6),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cpe.ts
+++ b/db/models/cpe.ts
@@ -59,11 +59,11 @@ Cpe.init(
       },
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cpePart.ts
+++ b/db/models/cpePart.ts
@@ -24,19 +24,19 @@ CpePart.init(
       autoIncrement: true,
     },
     partCode: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     partDefinition: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cpeProduct.ts
+++ b/db/models/cpeProduct.ts
@@ -26,15 +26,15 @@ CpeProduct.init(
       autoIncrement: true,
     },
     cpeProductString: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cpeVendor.ts
+++ b/db/models/cpeVendor.ts
@@ -26,15 +26,15 @@ CpeVendor.init(
       autoIncrement: true,
     },
     cpeVendorString: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cve.ts
+++ b/db/models/cve.ts
@@ -132,7 +132,7 @@ Cve.init(
       autoIncrement: true,
     },
     cveId: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     cvss3AttackComplexity: {
@@ -168,14 +168,14 @@ Cve.init(
       values: Object.values(cvss3UserInteraction),
     },
     cvss3Version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/cveOverride.ts
+++ b/db/models/cveOverride.ts
@@ -48,11 +48,11 @@ CveOverride.init(
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/evaluation.ts
+++ b/db/models/evaluation.ts
@@ -27,23 +27,23 @@ Evaluation.init(
       primaryKey: true,
     },
     classification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     customname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     comment: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/evaluationItem.ts
+++ b/db/models/evaluationItem.ts
@@ -53,22 +53,22 @@ EvaluationItem.init(
       autoIncrement: true,
     },
     Office_Org: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Resources_Required: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Scheduled_Completion_Date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
     },
     Milestone_Changes: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Poam_Comments: {
-      type: DataTypes.STRING(1024),
+      type: DataTypes.TEXT,
     },
     Mitigations: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Severity: {
       type: DataTypes.ENUM,
@@ -91,7 +91,7 @@ EvaluationItem.init(
       allowNull: true,
     },
     Impact_Description: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     Residual_Risk_Level: {
       type: DataTypes.ENUM,
@@ -99,14 +99,14 @@ EvaluationItem.init(
       allowNull: true,
     },
     Recommendations: {
-      type: DataTypes.STRING(256),
+      type: DataTypes.TEXT,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/milestone.ts
+++ b/db/models/milestone.ts
@@ -42,19 +42,19 @@ Milestone.init(
       allowNull: false,
     },
     item: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     completion_date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusOverride.ts
+++ b/db/models/nessusOverride.ts
@@ -44,19 +44,19 @@ NessusOverride.init(
       allowNull: false,
     },
     type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusPlugin.ts
+++ b/db/models/nessusPlugin.ts
@@ -64,22 +64,22 @@ NessusPlugin.init(
       allowNull: false,
     },
     pluginPublicationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     pluginModificationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     pluginName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fname: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     scriptVersion: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     severity: {
@@ -105,15 +105,15 @@ NessusPlugin.init(
       allowNull: false,
     },
     synopsis: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusPluginFamily.ts
+++ b/db/models/nessusPluginFamily.ts
@@ -26,15 +26,15 @@ NessusPluginFamily.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusReport.ts
+++ b/db/models/nessusReport.ts
@@ -37,23 +37,23 @@ NessusReport.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     reportHostName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     hash: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusReportItem.ts
+++ b/db/models/nessusReportItem.ts
@@ -64,37 +64,37 @@ NessusReportItem.init(
       allowNull: false,
     },
     ageOfVuln: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cisaKnownExploited: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     agent: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     alwaysRun: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetCategories: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetInventory: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     assetInventoryCategory: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     bid: {
       type: DataTypes.INTEGER,
     },
     cvss3TemporalVector: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cvss3TemporalScore: {
       type: DataTypes.DECIMAL,
     },
     cvssTemporalVector: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     cvssTemporalScore: {
       type: DataTypes.INTEGER,
@@ -103,20 +103,20 @@ NessusReportItem.init(
       type: DataTypes.INTEGER,
     },
     canvasPackage: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     ceaId: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     pluginOutput: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     severityOverride: {
       type: DataTypes.SMALLINT,
       allowNull: true,
     },
     severityOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     statusOverride: {
@@ -125,7 +125,7 @@ NessusReportItem.init(
       values: ["Not_Reviewed", "Open", "NotAFinding", "Not_Applicable"],
     },
     statusOverrideJustification: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     NessusPluginId: {
       type: DataTypes.INTEGER,
@@ -152,11 +152,11 @@ NessusReportItem.init(
       },
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/nessusServiceName.ts
+++ b/db/models/nessusServiceName.ts
@@ -26,15 +26,15 @@ NessusServiceName.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/notificationCategory.ts
+++ b/db/models/notificationCategory.ts
@@ -27,15 +27,15 @@ NotificationCategory.init(
       primaryKey: true,
     },
     category: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/override.ts
+++ b/db/models/override.ts
@@ -44,11 +44,11 @@ Override.init(
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/policyDocument.ts
+++ b/db/models/policyDocument.ts
@@ -27,21 +27,21 @@ PolicyDocument.init(
       autoIncrement: true,
     },
     title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: "TitleVersion",
     },
     version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: "TitleVersion",
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/protocols.ts
+++ b/db/models/protocols.ts
@@ -23,15 +23,15 @@ Protocol.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/session.ts
+++ b/db/models/session.ts
@@ -32,35 +32,35 @@ export class Session extends Model<InferAttributes<Session>, InferCreationAttrib
 Session.init(
   {
     id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       primaryKey: true,
     },
     expiresAt: {
-      type: DataTypes.STRING, // Store as ISO string
+      type: DataTypes.TEXT, // Store as ISO string
       allowNull: false,
     },
     authMethod: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     ipAddress: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     userAgent: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     loginTime: {
-      type: DataTypes.STRING, // Store as ISO string
+      type: DataTypes.TEXT, // Store as ISO string
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stig.ts
+++ b/db/models/stig.ts
@@ -74,100 +74,100 @@ Stig.init(
       allowNull: false,
     },
     dc: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xsi: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     cpe: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xhtml: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dsig: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     schemaLocation: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     stigid: {
       // Same as Benchmark.id in XML
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lang: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     xmlns: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     status: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     status__date: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING(2000),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     notice__id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     notice__lang: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     front_matter: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     rear_matter: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__href: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__publisher: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     reference__source: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__release_info: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__generator: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     plain_text__conventionsVersion: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     stigRelease: {
@@ -175,11 +175,11 @@ Stig.init(
       allowNull: false,
     },
     stigDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     filename: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     MAC1C: {
@@ -228,11 +228,11 @@ Stig.init(
       defaultValue: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigAlias.ts
+++ b/db/models/stigAlias.ts
@@ -25,19 +25,19 @@ StigAlias.init(
       primaryKey: true,
     },
     alias: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     identifier: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigData.ts
+++ b/db/models/stigData.ts
@@ -88,19 +88,19 @@ StigData.init(
       primaryKey: true,
     },
     vuln_num: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     group_title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -110,11 +110,11 @@ StigData.init(
       allowNull: true,
     },
     weight: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_ver: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     rule_title: {
@@ -126,19 +126,19 @@ StigData.init(
       allowNull: false,
     },
     false_positives: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     false_negatives: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     documentable: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     mitigations: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     security_override_guidance: {
@@ -146,27 +146,27 @@ StigData.init(
       allowNull: true,
     },
     potential_impact: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     third_party_tools: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     mitigation_control: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     responsibility: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     ia_controls: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     check__system: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     check_check_content: {
@@ -174,15 +174,15 @@ StigData.init(
       allowNull: false,
     },
     check_check_content_ref__name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     check_check_content_ref__href: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fix__id: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     fixtext: {
@@ -190,15 +190,15 @@ StigData.init(
       allowNull: false,
     },
     fixtext__fixref: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigIdent.ts
+++ b/db/models/stigIdent.ts
@@ -27,19 +27,19 @@ StigIdent.init(
       autoIncrement: true,
     },
     system: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     text: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigLibrary.ts
+++ b/db/models/stigLibrary.ts
@@ -47,12 +47,12 @@ StigLibrary.init(
       allowNull: false,
     },
     filename: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
     hash: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       unique: true,
       allowNull: false,
     },
@@ -62,7 +62,7 @@ StigLibrary.init(
       allowNull: true,
     },
     libraryDate: {
-      type: DataTypes.STRING(29),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     version: {
@@ -70,15 +70,15 @@ StigLibrary.init(
       allowNull: true,
     },
     importedDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: true, // not set until import is complete
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigOverride.ts
+++ b/db/models/stigOverride.ts
@@ -44,19 +44,19 @@ StigOverride.init(
       allowNull: false,
     },
     type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigReference.ts
+++ b/db/models/stigReference.ts
@@ -31,31 +31,31 @@ StigReference.init(
       allowNull: false,
     },
     dc_identifier: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_publisher: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_subject: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dc_type: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/stigResponsibility.ts
+++ b/db/models/stigResponsibility.ts
@@ -25,16 +25,16 @@ StigResponsibility.init(
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/theme.ts
+++ b/db/models/theme.ts
@@ -21,15 +21,15 @@ Theme.init(
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/tier.ts
+++ b/db/models/tier.ts
@@ -24,7 +24,7 @@ Tier.init(
       allowNull: false,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
@@ -32,11 +32,11 @@ Tier.init(
       type: DataTypes.INTEGER,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/tierRole.ts
+++ b/db/models/tierRole.ts
@@ -23,16 +23,16 @@ TierRole.init(
       allowNull: false,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/timezone.ts
+++ b/db/models/timezone.ts
@@ -21,14 +21,14 @@ Timezone.init(
       type: DataTypes.INTEGER,
       primaryKey: true,
     },
-    name: DataTypes.STRING(64),
-    abbreviation: DataTypes.STRING(5),
+    name: DataTypes.TEXT,
+    abbreviation: DataTypes.TEXT,
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/tirAlias.ts
+++ b/db/models/tirAlias.ts
@@ -23,19 +23,19 @@ TirAlias.init(
       primaryKey: true,
     },
     term: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     alias: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/tirConfig.ts
+++ b/db/models/tirConfig.ts
@@ -25,20 +25,20 @@ TirConfig.init(
       primaryKey: true,
     },
     key: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     value: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/tirNotifications.ts
+++ b/db/models/tirNotifications.ts
@@ -43,21 +43,21 @@ TirNotification.init(
       autoIncrement: true,
     },
     message: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     dueDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     daysLeft: {
       type: DataTypes.INTEGER,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/token.ts
+++ b/db/models/token.ts
@@ -24,23 +24,23 @@ Token.init(
       autoIncrement: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     token: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     date: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/user.ts
+++ b/db/models/user.ts
@@ -56,28 +56,28 @@ User.init(
       autoIncrement: true,
     },
     firstName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     lastName: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     email: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     password: {
-      type: DataTypes.STRING(128),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     organization: {
-      type: DataTypes.STRING(64),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     passwordChangedAt: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     forcePasswordChange: {
@@ -91,24 +91,24 @@ User.init(
       defaultValue: 0,
     },
     lastLogin: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     creationMethod: {
-      type: DataTypes.STRING(16),
+      type: DataTypes.TEXT,
       allowNull: false,
       defaultValue: "local",
     },
     salt: {
-      type: DataTypes.STRING(16),
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/models/userRole.ts
+++ b/db/models/userRole.ts
@@ -22,16 +22,16 @@ UserRole.init(
       primaryKey: true,
     },
     name: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       unique: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING(DATETIME_LENGTH),
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },

--- a/db/seeders/2024.04.23T20.37.14.OwnerChange.js
+++ b/db/seeders/2024.04.23T20.37.14.OwnerChange.js
@@ -86,14 +86,14 @@ export const up = async ({ context: sequelize }) => {
             await sequelize.query(`
         CREATE TABLE IF NOT EXISTS "Boundaries_backup" (
           "id" INTEGER PRIMARY KEY AUTOINCREMENT, 
-          "name" VARCHAR(255) NOT NULL UNIQUE, 
-          "lastUpdate" VARCHAR(29) NOT NULL, 
-          "creationDate" VARCHAR(29) NOT NULL, 
+          "name" TEXT NOT NULL UNIQUE, 
+          "lastUpdate" TEXT NOT NULL, 
+          "creationDate" TEXT NOT NULL, 
           "TierId" INTEGER NOT NULL REFERENCES "Tiers" ("id") ON DELETE CASCADE ON UPDATE CASCADE, 
           "StigLibraryId" INTEGER REFERENCES "StigLibraries" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
           "PolicyDocumentId" INTEGER NOT NULL REFERENCES "PolicyDocuments" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
           "ClassificationId" INTEGER REFERENCES "Classifications" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
-          "caveats" VARCHAR(50)
+          "caveats" TEXT
         );`);
             await sequelize.query(`
         INSERT INTO "Boundaries_backup" 
@@ -104,14 +104,14 @@ export const up = async ({ context: sequelize }) => {
             await sequelize.query(`
         CREATE TABLE IF NOT EXISTS "Boundaries" (
           "id" INTEGER PRIMARY KEY AUTOINCREMENT, 
-          "name" VARCHAR(255) NOT NULL UNIQUE, 
-          "lastUpdate" VARCHAR(29) NOT NULL, 
-          "creationDate" VARCHAR(29) NOT NULL, 
+          "name" TEXT NOT NULL UNIQUE, 
+          "lastUpdate" TEXT NOT NULL, 
+          "creationDate" TEXT NOT NULL, 
           "TierId" INTEGER NOT NULL REFERENCES "Tiers" ("id") ON DELETE CASCADE ON UPDATE CASCADE, 
           "StigLibraryId" INTEGER REFERENCES "StigLibraries" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
           "PolicyDocumentId" INTEGER NOT NULL REFERENCES "PolicyDocuments" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
           "ClassificationId" INTEGER REFERENCES "Classifications" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
-          "caveats" VARCHAR(50)
+          "caveats" TEXT
         );`);
             await sequelize.query(`
         INSERT INTO "Boundaries" 
@@ -122,10 +122,10 @@ export const up = async ({ context: sequelize }) => {
             await sequelize.query(`
         CREATE TABLE IF NOT EXISTS "Tiers_backup" (
           "id" INTEGER PRIMARY KEY AUTOINCREMENT, 
-          "name" VARCHAR(255) NOT NULL UNIQUE, 
+          "name" TEXT NOT NULL UNIQUE, 
           "parentId" INTEGER REFERENCES "Tiers_backup" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-          "lastUpdate" VARCHAR(29) NOT NULL, 
-          "creationDate" VARCHAR(29) NOT NULL
+          "lastUpdate" TEXT NOT NULL, 
+          "creationDate" TEXT NOT NULL
         );`);
             await sequelize.query(`
         INSERT INTO "Tiers_backup" 
@@ -137,10 +137,10 @@ export const up = async ({ context: sequelize }) => {
             await sequelize.query(`
         CREATE TABLE IF NOT EXISTS "Tiers" (
           "id" INTEGER PRIMARY KEY AUTOINCREMENT, 
-          "name" VARCHAR(255) NOT NULL UNIQUE, 
+          "name" TEXT NOT NULL UNIQUE, 
           "parentId" INTEGER REFERENCES "Tiers" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-          "lastUpdate" VARCHAR(29) NOT NULL, 
-          "creationDate" VARCHAR(29) NOT NULL
+          "lastUpdate" TEXT NOT NULL, 
+          "creationDate" TEXT NOT NULL
         );`);
             await sequelize.query(`
         INSERT INTO "Tiers" 

--- a/db/templates/sample-migration.js
+++ b/db/templates/sample-migration.js
@@ -10,11 +10,11 @@ export const up = async () => {
       autoIncrement: true,
     },
     lastUpdate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     creationDate: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   });

--- a/db/umzug.js
+++ b/db/umzug.js
@@ -134,4 +134,3 @@ export const seeder = new Umzug({
   },
 });
 
-export const DATETIME_LENGTH = 29;

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -1,4 +1,3 @@
-export const DATETIME_LENGTH = 29;
 export const MAX_IPV6_STRING_LENGTH = 39;
 export const MAX_MAC_ADDRESS_STRING_LENGTH = 17;
 export const MAX_FQDN_STRING_LENGTH = 253;


### PR DESCRIPTION
## Summary

Removes every hard text-length limit from the database schema (#12),  in the models, throughout the historical migration chain, and on existing deployments via a new idempotent normalizing migration.  Converts all migrations to consume the Sequelize instance from umzug's context argument instead of importing it from db/umzug.js.

## Changes

refactor(db): replace all varchar column types with TEXT
- All DataTypes.STRING / STRING(n) / STRING(DATETIME_LENGTH) in migrations and models to DataTypes.TEXT 
- Raw-SQL VARCHAR(n) in the SQLite table rebuild blocks move to TEXT.  Also fixes a parenless VARCHAR${DATETIME_LENGTH} typo that produced the type name VARCHAR29
- DATETIME_LENGTH deleted from both definitions (db/umzug.js, server/utils/constants.ts) and from all migration import lists.  Sample migration template updated

fix(db): add idempotent migration converting existing varchar columns to TEXT
- Inspects information_schema for character varying columns, excluding SequelizeMeta and seeder_meta, and alters each to TEXT, rewriting column defaults carrying a ::character varying cast
- Postgres-only: SQLite never enforced the lengths
- No-op by construction on databases built from the rewritten chain

refactor(db): migrations consume the umzug context instead of importing the instance
- All migrations: import { sequelize } from "../umzug.js" removed. up/down become async ({ context: sequelize })
- In the packaged app this stops migration files loading a second copy of umzug.js from disk (second connection pool, duplicate hooks, runtime dotenv). The dev CLI (db/migrate.js / db/seed.js) is unaffected

## Testing

- Convergence: fresh database from the rewritten chain vs. a pre-change database after the normalizer.  pg_dump --schema-only byte-identical, including the default-cast case (Users.creationMethod)
- Upgrade safety: against an already-migrated database, migrate pending lists nothing after the normalizer.
- Fresh install via dev CLI: node db/migrate.js up && node db/seed.js up applies 56 migrations + 13 seeders cleanly with context-injected migrations
- Idempotency: re-running the normalizer converts nothing

## Related

Closes #12
