### PR TITLE
feat(sctm): add technical assessment section to control view

### DIFF
--- a/components/sctm/SecurityAssessment.vue
+++ b/components/sctm/SecurityAssessment.vue
@@ -255,7 +255,7 @@
 
 <script setup lang="ts">
 import { CheckIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
-import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions, Transition } from "@headlessui/vue";
+import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from "@headlessui/vue";
 
 interface DropdownItem {
   id: number;

--- a/components/sctm/TechnicalAssessment.vue
+++ b/components/sctm/TechnicalAssessment.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="relative inline-block">
+    <h1 class="mb-2 cursor-help text-black underline dark:text-white">Technical Assessment Status</h1>
+  </div>
+  <div class="grid grid-cols-8 gap-x-6 gap-y-8">
+    <div class="col-span-8">
+      <div class="">
+        <text class="font-light text-black dark:text-gray-200"> {{ item.technicalAssessmentStatus }} </text>
+      </div>
+    </div>
+  </div>
+  <div class="relative mt-4 inline-block">
+    <h1 class="cursor-help text-black underline dark:text-white">Technical Assessment Comments</h1>
+  </div>
+  <div class="grid grid-cols-8 gap-x-6 gap-y-8">
+    <div class="col-span-8">
+      <div class="whitespace-pre-wrap">
+        <div
+          v-for="(line, index) in item.technicalAssessmentComments"
+          :key="index"
+          :class="{
+            'pt-2 text-red-500': line.trim() === 'Open',
+            'pt-2 text-green-500': line.trim() === 'NotAFinding',
+            'pt-2 text-sky-500': line.trim() === 'Not_Applicable',
+            'pt-2 text-amber-500': line.trim() === 'Not_Reviewed',
+            'font-light text-black dark:text-gray-200': ![
+              'Open',
+              'NotAFinding',
+              'Not_Applicable',
+              'Not_Reviewed',
+            ].includes(line.trim()),
+          }"
+          class="block"
+        >
+          {{ line }}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="relative mt-4 inline-block">
+    <h1 class="mb-2 cursor-help text-black underline dark:text-white">CCI</h1>
+  </div>
+  <div class="grid grid-cols-8 gap-x-6 gap-y-8">
+    <div class="col-span-8">
+      <div class=" whitespace-pre-wrap">
+        <text class="font-light text-black dark:text-gray-200">
+          {{ item.cci }}
+        </text>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface DropdownItem {
+  id: number;
+  name: string;
+}
+
+const props = defineProps({
+  evaluationItem: { type: Object, required: true },
+  complianceStatus: { type: Array as PropType<DropdownItem[]>, required: true },
+});
+
+const item = toRef(props, "evaluationItem");
+</script>

--- a/pages/company-boundary/[boundaryId]/SCTM/[sctmId].vue
+++ b/pages/company-boundary/[boundaryId]/SCTM/[sctmId].vue
@@ -294,6 +294,35 @@
                     'flex h-16 w-full items-center justify-between rounded-t-lg px-4 py-2 text-left text-lg font-medium text-gray-800 hover:bg-gray-300 focus:outline-none focus-visible:ring focus-visible:ring-purple-500  focus-visible:ring-opacity-75 dark:text-white dark:hover:bg-gray-900',
                   ]"
                 >
+                  Technical Assessment
+                  <ChevronRightIcon :class="[open && 'rotate-90 transform', 'h-6 w-6']" />
+                </DisclosureButton>
+                <transition
+                  enter-active-class="transition duration-100 ease-out"
+                  enter-from-class="transform scale-95 opacity-0"
+                  enter-to-class="transform scale-100 opacity-100"
+                  leave-active-class="transition duration-75 ease-out"
+                  leave-from-class="transform scale-100 opacity-100"
+                  leave-to-class="transform scale-95 opacity-0"
+                >
+                  <DisclosurePanel
+                    class="h-84 text-md w-full rounded-b-lg bg-gray-300/5 px-4 py-4 text-left font-medium text-white focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75"
+                  >
+                    <sctmTechnicalAssessment
+                      v-if="dropdowns"
+                      :evaluation-item="controlRecordItem"
+                      :compliance-status="dropdowns['compliance-statuses'] || []"
+                    />
+                  </DisclosurePanel>
+                </transition>
+              </Disclosure>
+              <Disclosure v-slot="{ open }" :default-open="true" as="div" class="mb-2 pr-4">
+                <DisclosureButton
+                  :class="[
+                    open ? 'bg-gray-300 dark:bg-gray-900' : 'rounded-b-lg bg-gray-900/10 dark:bg-gray-300/5',
+                    'flex h-16 w-full items-center justify-between rounded-t-lg px-4 py-2 text-left text-lg font-medium text-gray-800 hover:bg-gray-300 focus:outline-none focus-visible:ring focus-visible:ring-purple-500  focus-visible:ring-opacity-75 dark:text-white dark:hover:bg-gray-900',
+                  ]"
+                >
                   Security Assessment
                   <ChevronRightIcon :class="[open && 'rotate-90 transform', 'h-6 w-6']" />
                 </DisclosureButton>

--- a/server/utils/controls.ts
+++ b/server/utils/controls.ts
@@ -380,15 +380,15 @@ function getTechnicalAssessment(
 
   if (!statusMap || statusMap.size === 0) {
     return {
-      cci: "",
-      technicalAssessmentStatus: "",
+      cci: cciIds.map((cciId) => `  ${cciId}: Not-Applicable`).join("\n"),
+      technicalAssessmentStatus: "Not-Applicable",
       technicalAssessmentComments: [
         "No applicable STIG mapping for this Control.",
       ],
     };
   }
 
-  let cci = "";
+  const cciLines: string[] = [];
 
   for (const cciId of cciIds) {
     const cciVKeys: { vKey: string; status: string }[] = [];
@@ -404,16 +404,16 @@ function getTechnicalAssessment(
       }
     }
 
-    if (cciVKeys.length === 0) {
-      continue;
-    }
+    const cciStatus =
+      cciVKeys.length > 0
+        ? determineCciStatus(cciVKeys)
+        : "Not-Applicable";
 
-    const cciStatus = determineCciStatus(cciVKeys);
-    cci += `  ${cciId}: ${cciStatus}\n`;
+    cciLines.push(`  ${cciId}: ${cciStatus}`);
   }
 
   return {
-    cci,
+    cci: cciLines.join("\n"),
     technicalAssessmentStatus: evaluateStatuses(statusMap),
     technicalAssessmentComments: buildDisplayLines(statusMap),
   };
@@ -460,7 +460,10 @@ function buildCciMaps(cciItems: Awaited<ReturnType<typeof loadCciItems>>) {
       const controlNumber = parseTopLevelControl(reference.index);
       const mappedCcis = cciMap.get(controlNumber) ?? [];
 
-      mappedCcis.push(item.cciId);
+      if (!mappedCcis.includes(item.cciId)) {
+        mappedCcis.push(item.cciId);
+      }
+
       cciMap.set(controlNumber, mappedCcis);
     }
   }

--- a/server/utils/controls.ts
+++ b/server/utils/controls.ts
@@ -363,6 +363,62 @@ function determineCciStatus(cciVKeys: { vKey: string; status: string }[]): strin
   }
 }
 
+interface TechnicalAssessment {
+  cci: string;
+  technicalAssessmentStatus: string;
+  technicalAssessmentComments: string[];
+}
+
+function getTechnicalAssessment(
+  normalizedControlNumber: string,
+  controlToStatusMap: Map<string, Map<string, Set<string>>>,
+  cciMap: Map<string, string[]>,
+  stigLookup: Record<string, { cciIds: Set<string>; stig: any }>,
+): TechnicalAssessment {
+  const statusMap = controlToStatusMap.get(normalizedControlNumber);
+  const cciIds = cciMap.get(normalizedControlNumber) ?? [];
+
+  if (!statusMap || statusMap.size === 0) {
+    return {
+      cci: "",
+      technicalAssessmentStatus: "",
+      technicalAssessmentComments: [
+        "No applicable STIG mapping for this Control.",
+      ],
+    };
+  }
+
+  let cci = "";
+
+  for (const cciId of cciIds) {
+    const cciVKeys: { vKey: string; status: string }[] = [];
+
+    for (const [status, vKeys] of statusMap) {
+      for (const displayValue of vKeys) {
+        const vKey = displayValue.split(" - ")[0];
+        const stigEntry = stigLookup[vKey];
+
+        if (stigEntry?.cciIds.has(cciId)) {
+          cciVKeys.push({ vKey, status });
+        }
+      }
+    }
+
+    if (cciVKeys.length === 0) {
+      continue;
+    }
+
+    const cciStatus = determineCciStatus(cciVKeys);
+    cci += `  ${cciId}: ${cciStatus}\n`;
+  }
+
+  return {
+    cci,
+    technicalAssessmentStatus: evaluateStatuses(statusMap),
+    technicalAssessmentComments: buildDisplayLines(statusMap),
+  };
+}
+
 export async function getControlSummary(
   BoundaryId: number,
   ControlRecordId: number,
@@ -478,19 +534,32 @@ export async function getControlSummary(
 
       for (const cciId of cciIds) {
         const cciItem = cciItemMap.get(cciId);
-        const cciRef = cciItem?.CciReferences?.[0]?.index ?? "";
-        const normalizedControl = parseTopLevelControl(cciRef);
-        if (!normalizedControl) continue;
+        const cciReferences = cciItem?.CciReferences ?? [];
 
-        if (!controlToStatusMap.has(normalizedControl)) {
-          controlToStatusMap.set(normalizedControl, new Map());
-        }
+        for (const cciReference of cciReferences) {
+          if (!cciReference.index) continue;
 
-        const statusMap = controlToStatusMap.get(normalizedControl)!;
-        if (!statusMap.has(status)) {
-          statusMap.set(status, new Set());
+          const normalizedControl = parseTopLevelControl(
+            cciReference.index,
+          );
+
+          if (!normalizedControl) continue;
+
+          if (!controlToStatusMap.has(normalizedControl)) {
+            controlToStatusMap.set(
+              normalizedControl,
+              new Map<string, Set<string>>(),
+            );
+          }
+
+          const statusMap = controlToStatusMap.get(normalizedControl)!;
+
+          if (!statusMap.has(status)) {
+            statusMap.set(status, new Set<string>());
+          }
+
+          statusMap.get(status)!.add(displayValue);
         }
-        statusMap.get(status)!.add(displayValue);
       }
     }
   }
@@ -502,89 +571,50 @@ export async function getControlSummary(
     if (!match) return cleaned;
     return match[1] + (match[2] || "");
   }
-  const controlSummaries: (ControlSummary | EnhancementSummary)[] = results.map((item) => {
-    if (item.ControlEnhancementId && item.ControlEnhancement) {
-      const normalizedControlNumber = parseTopLevelControl(
-        item.ControlEnhancement.enhancementIdentifier,
-      );
-      const statusMap = controlToStatusMap.get(normalizedControlNumber);
-      const cciIds = cciMap.get(normalizedControlNumber) || [];
-      let cci = "";
-      let technicalAssessmentComments;
-      let technicalAssessmentStatus = "";
-      if (statusMap && statusMap.size > 0) {
-        technicalAssessmentStatus = evaluateStatuses(statusMap);
-        const displayLines = buildDisplayLines(statusMap);
+  const controlSummaries: (ControlSummary | EnhancementSummary)[] =
+    results.map((item) => {
+      if (item.ControlEnhancementId && item.ControlEnhancement) {
+        const normalizedControlNumber = parseTopLevelControl(
+          item.ControlEnhancement.enhancementIdentifier,
+        );
 
-        technicalAssessmentComments = displayLines;
+        const assessment = getTechnicalAssessment(
+          normalizedControlNumber,
+          controlToStatusMap,
+          cciMap,
+          stigLookup,
+        );
 
-        for (const cciId of cciIds) {
-          const cciVKeys: { vKey: string; status: string }[] = [];
-          for (const [status, vKeys] of statusMap) {
-            for (const vKey of vKeys) {
-              const originalVKey = vKey.split(" - ")[0];
-              if (stigLookup[originalVKey] && stigLookup[originalVKey].cciIds.has(cciId)) {
-                cciVKeys.push({ vKey: originalVKey, status });
-              }
-            }
-          }
-          if (cciVKeys.length === 0) {
-            continue;
-          }
-          const cciStatus = determineCciStatus(cciVKeys);
-          cci += `  ${cciId}: ${cciStatus || "Not Reviewed"}\n`;
-        }
-      } else {
-        technicalAssessmentComments = ["No applicable STIG mapping for this Control."];
+        return getEnhancementSummary(
+          item,
+          assessment.cci,
+          assessment.technicalAssessmentStatus,
+          assessment.technicalAssessmentComments,
+        );
       }
-      const result = getEnhancementSummary(
-        item,
-        cci,
-        technicalAssessmentStatus,
-        technicalAssessmentComments,
-      );
-      return result;
-    }
-    if (item.Control && item.Control.ControlNumber) {
-      const normalizedControlNumber = parseTopLevelControl(item.Control.ControlNumber.number);
-      const statusMap = controlToStatusMap.get(normalizedControlNumber);
-      const cciIds = cciMap.get(normalizedControlNumber) || [];
-      let cci = "";
-      let technicalAssessmentComments;
-      let technicalAssessmentStatus = "";
-      if (statusMap && statusMap.size > 0) {
-        technicalAssessmentStatus = evaluateStatuses(statusMap);
-        const displayLines = buildDisplayLines(statusMap);
-        technicalAssessmentComments = displayLines;
 
-        for (const cciId of cciIds) {
-          const cciVKeys: { vKey: string; status: string }[] = [];
-          for (const [status, vKeys] of statusMap) {
-            for (const vKey of vKeys) {
-              const originalVKey = vKey.split(" - ")[0];
-              if (stigLookup[originalVKey] && stigLookup[originalVKey].cciIds.has(cciId)) {
-                cciVKeys.push({ vKey: originalVKey, status });
-              }
-            }
-          }
-          if (cciVKeys.length === 0) {
-            continue;
-          }
-          const cciStatus = determineCciStatus(cciVKeys);
-          cci += `  ${cciId}: ${cciStatus || "Not Reviewed"}\n`;
-        }
-      } else {
-        technicalAssessmentComments = ["No applicable STIG mapping for this Control."];
+      if (item.Control?.ControlNumber) {
+        const normalizedControlNumber = parseTopLevelControl(
+          item.Control.ControlNumber.number,
+        );
+
+        const assessment = getTechnicalAssessment(
+          normalizedControlNumber,
+          controlToStatusMap,
+          cciMap,
+          stigLookup,
+        );
+
+        return getStandardControlSummary(
+          item,
+          assessment.cci,
+          assessment.technicalAssessmentStatus,
+          assessment.technicalAssessmentComments,
+        );
       }
-      const result = getStandardControlSummary(
-        item,
-        cci,
-        technicalAssessmentStatus,
-        technicalAssessmentComments,
-      );
-      return result;
-    }
-    throw new Error("ControlRecordItem without Control or Enhancement");
-  });
+
+      throw new Error("ControlRecordItem without Control or Enhancement");
+    });
+
   return controlSummaries;
 }

--- a/server/utils/controls.ts
+++ b/server/utils/controls.ts
@@ -10,67 +10,162 @@ import {
   ControlStatement,
   ControlEnhancement,
   ControlEnhancementStatement,
+  Boundary,
+  Classification,
+  PolicyDocument,
+  CciReference,
+  CciItem,
 } from "../../db/models";
 
-export interface ControlSummary {
+interface BaseFields {
   ControlRecordItemId: number;
-  id: number; // controlId OR enhancementId
-  number: string; // controlNumber OR enhancementIdentifier
+  family: string;
+  ComplianceStatusId: number;
+  ImplementationStatusId: number;
+  CommonControlProviderId: number;
+  systemProvider: string;
+  SecurityControlDesignationId: number;
+  TestMethodId: number;
+  naJustification: string;
+  estimatedCompletionDate: string;
+  implementationNarrative: string;
+  responsibleEntities: string;
+  criticality: string;
+  FrequencyTypeId: number;
+  ConMonMethodId: number;
+  reporting: string;
+  tracking: string;
+  conmonComments: string;
+  SeverityId: number;
+  RelevanceOfThreatId: number;
+  LikelihoodId: number;
+  ImpactId: number;
+  ResidualRiskLevelId: number;
+  vulnerabilitySummary: string;
+  mitigations: string;
+  impactDescription: string;
+  recommendations: string;
+  auditor: string;
+  AuditControlStatusId: number;
+  auditDate: string;
+  auditComments: string;
+  assessor: string;
+  AssessorControlStatusId: number;
+  assessorDate: string;
+  assessorComments: string;
+  lastUpdate: string;
+  creationDate: string;
+}
+interface ControlSummary extends BaseFields {
+  type: "control";
+  id: number;
+  number: string;
   title: string;
-  revision: string; // controls have it, enhancements can be blank
+  revision: string;
   guidance: string;
-  statements: Array<any>; // ControlStatements OR ControlEnhancementStatements
-  type: "control" | "enhancement";
+  statements: string[];
+  cci: string;
+  technicalAssessmentStatus: string;
+  technicalAssessmentComments: string[];
+}
+
+interface EnhancementSummary extends BaseFields {
+  type: "enhancement";
+  id: number;
+  number: string;
+  title: string;
+  revision: string;
+  guidance: string;
+  statements: string[];
+  cci: string;
+  technicalAssessmentStatus: string;
+  technicalAssessmentComments: string[];
+}
+interface NewRecord {
+  BoundaryId: number;
+  ControlFamilyId: number;
+  ControlRevisionId: number;
+  lastUpdate: string;
+  creationDate: string;
+}
+
+interface NewItem {
+  ControlRecordId: number;
+  ControlId: number;
+  ComplianceStatusId: number;
+  ControlEnhancementId?: number;
+  AssessorControlStatusId: number;
+  AuditControlStatusId: number;
+  lastUpdate: string;
+  creationDate: string;
+}
+
+interface InsertedControlRecord {
+  id: number;
+  ControlFamilyId: number;
 }
 
 export async function createControlRecords(BoundaryId: number, controlRev: string) {
   const revName = `rev${controlRev}`;
   const now = DateTime.now().toISO();
-  // Get revision
-  const revision = await ControlRevision.findOne({ where: { name: revName } });
+
+  const revision = await ControlRevision.findOne({
+    where: { name: revName },
+    attributes: ["id"],
+  });
   if (!revision) {
-    console.warn(`Revision ${revName} not found. Skipping...`);
-    return; // just exit the function early
+    throw createError({
+      statusCode: 404,
+      statusMessage: `Control Revision ${revName} not found.`,
+    });
   }
 
-  // Default compliance status
-  const notReviewedStatus = await ComplianceStatus.findOne({ where: { status: "Not Reviewed" } });
-  if (!notReviewedStatus) throw new Error(`Not Reviewed compliance status not found`);
+  const notReviewedStatus = await ComplianceStatus.findOne({
+    where: { status: "Not Reviewed" },
+    attributes: ["id"],
+  });
+  if (!notReviewedStatus) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Not Reviewed compliance status not found.",
+    });
+  }
 
-  // Get all control families with their controls + enhancements for this revision
   const controlFamilies = await ControlFamily.findAll({
+    attributes: ["id"],
     include: [
       {
         model: Control,
         required: true,
+        attributes: ["id", "ControlFamilyId"],
         include: [
           {
             model: ControlRevision,
             where: { id: revision.id },
             required: true,
+            attributes: [],
           },
           {
             model: ControlEnhancement,
+            attributes: ["id", "ControlId"],
           },
         ],
       },
     ],
   });
 
-  // Fetch existing ControlRecords for this boundary + revision to avoid duplicates
   const existingRecords = await ControlRecord.findAll({
     where: { BoundaryId, ControlRevisionId: revision.id },
     attributes: ["id", "ControlFamilyId"],
   });
   const existingRecordMap = new Map(existingRecords.map((r) => [r.ControlFamilyId, r.id]));
 
-  const newRecords: any[] = [];
-  const newItems: any[] = [];
+  const newRecords: NewRecord[] = [];
+  const newItems: NewItem[] = [];
 
   for (const family of controlFamilies) {
     const recordId = existingRecordMap.get(family.id);
     if (!recordId) {
-      // Prepare new ControlRecord
       newRecords.push({
         BoundaryId,
         ControlFamilyId: family.id,
@@ -81,87 +176,207 @@ export async function createControlRecords(BoundaryId: number, controlRev: strin
     }
   }
 
-  // Bulk insert new ControlRecords and get their IDs
-  let insertedRecords: any[] = [];
-  if (newRecords.length > 0) {
-    try {
-      insertedRecords = await ControlRecord.bulkCreate(newRecords, { returning: true });
-      insertedRecords.forEach((r: any) => existingRecordMap.set(r.ControlFamilyId, r.id));
-    } catch (err: any) {
-      if (err.name === "SequelizeValidationError") {
-        console.error(
-          "Validation error messages:",
-          err.errors.map((e: any) => e.message),
-        );
-        console.error(
-          "Invalid fields:",
-          err.errors.map((e: any) => e.path),
-        );
-      } else if (err.name === "SequelizeForeignKeyConstraintError") {
-        console.error("Foreign key constraint error:", err.fields);
-      } else {
-        console.error("Unexpected error inserting ControlRecords:", err);
-      }
-    }
-  }
-
-  // Prepare ControlRecordItems
-  for (const family of controlFamilies) {
-    const recordId = existingRecordMap.get(family.id);
-    if (!recordId) continue;
-    const controls = family.Controls ?? [];
-    for (const control of controls) {
-      // Base control item
-      newItems.push({
-        ControlRecordId: recordId,
-        ControlId: control.id,
-        ComplianceStatusId: notReviewedStatus.id,
-        AssessorControlStatusId: notReviewedStatus.id,
-        AuditControlStatusId: notReviewedStatus.id,
-        lastUpdate: now,
-        creationDate: now,
-      });
-
-      // Enhancements
-      for (const enhancement of control.ControlEnhancements || []) {
-        newItems.push({
-          ControlRecordId: recordId,
-          ControlId: control.id,
-          ControlEnhancementId: enhancement.id,
-          ComplianceStatusId: notReviewedStatus.id,
-          AssessorControlStatusId: notReviewedStatus.id,
-          AuditControlStatusId: notReviewedStatus.id,
-          lastUpdate: now,
-          creationDate: now,
+  try {
+    await sequelize.transaction(async (t) => {
+      let insertedRecords: InsertedControlRecord[] = [];
+      if (newRecords.length > 0) {
+        insertedRecords = await ControlRecord.bulkCreate(newRecords, {
+          returning: ["id", "ControlFamilyId"],
+          transaction: t,
         });
+        insertedRecords.forEach((r) => existingRecordMap.set(r.ControlFamilyId, r.id));
       }
-    }
+
+      for (const family of controlFamilies) {
+        const recordId = existingRecordMap.get(family.id);
+        if (!recordId) continue;
+        const controls = family.Controls ?? [];
+        for (const control of controls) {
+          newItems.push({
+            ControlRecordId: recordId,
+            ControlId: control.id,
+            ComplianceStatusId: notReviewedStatus.id,
+            AssessorControlStatusId: notReviewedStatus.id,
+            AuditControlStatusId: notReviewedStatus.id,
+            lastUpdate: now,
+            creationDate: now,
+          });
+          for (const enhancement of control.ControlEnhancements || []) {
+            newItems.push({
+              ControlRecordId: recordId,
+              ControlId: control.id,
+              ControlEnhancementId: enhancement.id,
+              ComplianceStatusId: notReviewedStatus.id,
+              AssessorControlStatusId: notReviewedStatus.id,
+              AuditControlStatusId: notReviewedStatus.id,
+              lastUpdate: now,
+              creationDate: now,
+            });
+          }
+        }
+      }
+
+      if (newItems.length > 0) {
+        await ControlRecordItem.bulkCreate(newItems, { transaction: t });
+      }
+    });
+
+    logger.info({
+      service: "SCTM",
+      message: `ControlRecords and items ensured for boundary ${BoundaryId} and revision ${revName}`,
+    });
+  } catch (err: any) {
+    logger.error({
+      service: "SCTM",
+      message: `Failed to create control records for boundary ${BoundaryId} rev ${revName}`,
+      error: err.message,
+    });
+    throw createError({
+      statusCode: 500,
+      statusMessage: `Failed to create control records for boundary ${BoundaryId} rev ${revName}`,
+    });
+  }
+}
+
+function getBaseFields(item: any): BaseFields {
+  return {
+    ControlRecordItemId: item.id,
+    family: item.Control.ControlFamily?.name || "",
+    ComplianceStatusId: item.ComplianceStatusId,
+    ImplementationStatusId: item.ImplementationStatusId,
+    CommonControlProviderId: item.CommonControlProviderId,
+    systemProvider: item.systemProvider,
+    SecurityControlDesignationId: item.SecurityControlDesignationId,
+    TestMethodId: item.TestMethodId,
+    naJustification: item.naJustification,
+    estimatedCompletionDate: item.estimatedCompletionDate,
+    implementationNarrative: item.implementationNarrative,
+    responsibleEntities: item.responsibleEntities,
+    criticality: item.criticality,
+    FrequencyTypeId: item.FrequencyTypeId,
+    ConMonMethodId: item.ConMonMethodId,
+    reporting: item.reporting,
+    tracking: item.tracking,
+    conmonComments: item.conmonComments,
+    SeverityId: item.SeverityId,
+    RelevanceOfThreatId: item.RelevanceOfThreatId,
+    LikelihoodId: item.LikelihoodId,
+    ImpactId: item.ImpactId,
+    ResidualRiskLevelId: item.ResidualRiskLevelId,
+    vulnerabilitySummary: item.vulnerabilitySummary,
+    mitigations: item.mitigations,
+    impactDescription: item.impactDescription,
+    recommendations: item.recommendations,
+    auditor: item.auditor,
+    AuditControlStatusId: item.AuditControlStatusId,
+    auditDate: item.auditDate,
+    auditComments: item.auditComments,
+    assessor: item.assessor,
+    AssessorControlStatusId: item.AssessorControlStatusId,
+    assessorDate: item.assessorDate,
+    assessorComments: item.assessorComments,
+    lastUpdate: item.lastUpdate,
+    creationDate: item.creationDate,
+  };
+}
+
+function getStandardControlSummary(
+  item: any,
+  cci: string,
+  technicalAssessmentStatus: string,
+  technicalAssessmentComments: string[],
+): ControlSummary {
+  const baseFields = getBaseFields(item);
+  return {
+    type: "control",
+    id: item.Control.id,
+    number: item.Control.ControlNumber?.number || "",
+    title: item.Control.title,
+    revision: item.Control.ControlRevision?.name || "",
+    guidance: item.Control.guidance,
+    statements: item.Control.ControlStatements || [],
+    ...baseFields,
+    cci,
+    technicalAssessmentStatus,
+    technicalAssessmentComments,
+  };
+}
+
+function getEnhancementSummary(
+  item: any,
+  cci: string,
+  technicalAssessmentStatus: string,
+  technicalAssessmentComments: string[],
+): EnhancementSummary {
+  const baseFields = getBaseFields(item);
+  return {
+    type: "enhancement",
+    id: item.ControlEnhancement.id,
+    number: item.ControlEnhancement.enhancementIdentifier,
+    title: item.ControlEnhancement.title,
+    revision: "", // enhancements may not have a revision
+    guidance: item.ControlEnhancement.guidance,
+    statements: item.ControlEnhancement.ControlEnhancementStatements || [],
+    ...baseFields,
+    cci,
+    technicalAssessmentStatus,
+    technicalAssessmentComments,
+  };
+}
+
+function evaluateStatuses(statusMap: Map<string, Set<string>>): string {
+  if (!statusMap || statusMap.size === 0) {
+    return "Not-Applicable";
   }
 
-  // Optional: skip inserting if newItems is empty
-  if (newItems.length > 0) {
-    await ControlRecordItem.bulkCreate(newItems);
+  const statuses = Array.from(statusMap.keys());
+  if (statuses.some((status) => status.trim() === "Open")) {
+    return "Non-Compliant";
+  } else if (statuses.some((status) => status.trim() === "Not_Reviewed")) {
+    return "Not Reviewed";
+  } else if (statuses.some((status) => status.trim() === "NotAFinding")) {
+    return "Compliant";
+  } else if (statuses.some((status) => status.trim() === "Not_Applicable")) {
+    return "Not-Applicable";
+  } else {
+    return "Not-Applicable";
   }
+}
 
-  logger.info({
-    service: "SCTM",
-    message: `ControlRecords and items ensured for boundary ${BoundaryId} and revision ${revName}`,
-  });
+function buildDisplayLines(statusMap: Map<string, Set<string>>): string[] {
+  const lines: string[] = [];
+  for (const [status, vKeys] of statusMap) {
+    lines.push(status, ...Array.from(vKeys), "");
+  }
+  return lines;
+}
+
+function determineCciStatus(cciVKeys: { vKey: string; status: string }[]): string {
+  if (cciVKeys.some((cciVKey) => cciVKey.status === "Open")) {
+    return "Non-Compliant";
+  } else if (cciVKeys.some((cciVKey) => cciVKey.status === "Not_Reviewed")) {
+    return "Not Reviewed";
+  } else if (cciVKeys.some((cciVKey) => cciVKey.status === "NotAFinding")) {
+    return "Compliant";
+  } else {
+    return "Not-Applicable";
+  }
 }
 
 export async function getControlSummary(
   BoundaryId: number,
   ControlRecordId: number,
-): Promise<ControlSummary[]> {
+): Promise<(ControlSummary | EnhancementSummary)[]> {
   const perfTimer = new PerfTimer();
 
   perfTimer.start("Query");
   const results = await ControlRecordItem.findAll({
+    where: { ControlRecordId },
     include: [
       {
         model: ControlRecord,
         attributes: ["ControlFamilyId"],
-        where: { BoundaryId, id: ControlRecordId },
+        where: { BoundaryId },
         required: true,
         include: [{ model: ControlFamily, attributes: ["name"] }],
       },
@@ -200,109 +415,175 @@ export async function getControlSummary(
       ],
     ],
   });
-  perfTimer.stop("Query");
-  const controlSummaries: ControlSummary[] = results.map((item) => {
-    if (item.ControlEnhancementId && item.ControlEnhancement) {
-      return {
-        type: "enhancement",
-        ControlRecordItemId: item.id,
-        id: item.ControlEnhancement.id,
-        family: item.ControlRecord?.ControlFamily?.name || "",
-        number: item.ControlEnhancement.enhancementIdentifier,
-        title: item.ControlEnhancement.title,
-        revision: "", // enhancements may not have a revision
-        guidance: item.ControlEnhancement.guidance,
-        statements: item.ControlEnhancement.ControlEnhancementStatements || [],
-        ...{
-          ComplianceStatusId: item.ComplianceStatusId,
-          ImplementationStatusId: item.ImplementationStatusId,
-          CommonControlProviderId: item.CommonControlProviderId,
-          systemProvider: item.systemProvider,
-          SecurityControlDesignationId: item.SecurityControlDesignationId,
-          TestMethodId: item.TestMethodId,
-          naJustification: item.naJustification,
-          estimatedCompletionDate: item.estimatedCompletionDate,
-          implementationNarrative: item.implementationNarrative,
-          responsibleEntities: item.responsibleEntities,
-          criticality: item.criticality,
-          FrequencyTypeId: item.FrequencyTypeId,
-          ConMonMethodId: item.ConMonMethodId,
-          reporting: item.reporting,
-          tracking: item.tracking,
-          conmonComments: item.conmonComments,
-          SeverityId: item.SeverityId,
-          RelevanceOfThreatId: item.RelevanceOfThreatId,
-          LikelihoodId: item.LikelihoodId,
-          ImpactId: item.ImpactId,
-          ResidualRiskLevelId: item.ResidualRiskLevelId,
-          vulnerabilitySummary: item.vulnerabilitySummary,
-          mitigations: item.mitigations,
-          impactDescription: item.impactDescription,
-          recommendations: item.recommendations,
-          auditor: item.auditor,
-          AuditControlStatusId: item.AuditControlStatusId,
-          auditDate: item.auditDate,
-          auditComments: item.auditComments,
-          assessor: item.assessor,
-          AssessorControlStatusId: item.AssessorControlStatusId,
-          assessorDate: item.assessorDate,
-          assessorComments: item.assessorComments,
-          lastUpdate: item.lastUpdate,
-          creationDate: item.creationDate,
-        },
-      };
-    }
-    if (item.Control) {
-      return {
-        type: "control",
-        ControlRecordItemId: item.id,
-        id: item.Control.id,
-        family: item.ControlRecord?.ControlFamily?.name || "",
-        number: item.Control.ControlNumber?.number || "",
-        title: item.Control.title,
-        revision: item.Control.ControlRevision?.name || "",
-        guidance: item.Control.guidance,
-        statements: item.Control.ControlStatements || [],
-        ...{
-          ComplianceStatusId: item.ComplianceStatusId,
-          ImplementationStatusId: item.ImplementationStatusId,
-          CommonControlProviderId: item.CommonControlProviderId,
-          systemProvider: item.systemProvider,
-          SecurityControlDesignationId: item.SecurityControlDesignationId,
-          TestMethodId: item.TestMethodId,
-          naJustification: item.naJustification,
-          estimatedCompletionDate: item.estimatedCompletionDate,
-          implementationNarrative: item.implementationNarrative,
-          responsibleEntities: item.responsibleEntities,
-          criticality: item.criticality,
-          FrequencyTypeId: item.FrequencyTypeId,
-          ConMonMethodId: item.ConMonMethodId,
-          reporting: item.reporting,
-          tracking: item.tracking,
-          conmonComments: item.conmonComments,
-          SeverityId: item.SeverityId,
-          RelevanceOfThreatId: item.RelevanceOfThreatId,
-          LikelihoodId: item.LikelihoodId,
-          ImpactId: item.ImpactId,
-          ResidualRiskLevelId: item.ResidualRiskLevelId,
-          vulnerabilitySummary: item.vulnerabilitySummary,
-          mitigations: item.mitigations,
-          impactDescription: item.impactDescription,
-          recommendations: item.recommendations,
-          auditor: item.auditor,
-          AuditControlStatusId: item.AuditControlStatusId,
-          auditDate: item.auditDate,
-          auditComments: item.auditComments,
-          assessor: item.assessor,
-          AssessorControlStatusId: item.AssessorControlStatusId,
-          assessorDate: item.assessorDate,
-          assessorComments: item.assessorComments,
-          lastUpdate: item.lastUpdate,
-          creationDate: item.creationDate,
-        },
-      };
-    }
 
+  const boundary = await Boundary.findOne({
+    where: { id: BoundaryId },
+    include: [
+      {
+        model: Classification,
+      },
+      {
+        model: PolicyDocument,
+      },
+    ],
+  });
+
+  const cciItems = await CciItem.findAll({
+    attributes: ["cciId", "definition"],
+    include: [
+      {
+        model: CciReference,
+        attributes: ["index"],
+        through: { attributes: [] },
+        where: {
+          PolicyDocumentId: boundary?.PolicyDocumentId,
+        },
+      },
+    ],
+  });
+  const cciItemMap = new Map(cciItems.map((item) => [item.cciId, item]));
+  const cciMap = new Map<string, string[]>();
+
+  for (const cciItem of cciItems) {
+    const refs = cciItem.CciReferences ?? [];
+    for (const ref of refs) {
+      if (!ref.index) continue;
+      const normalizedIndex = parseTopLevelControl(ref.index);
+      if (!cciMap.has(normalizedIndex)) {
+        cciMap.set(normalizedIndex, []);
+      }
+      cciMap.get(normalizedIndex)!.push(cciItem.cciId);
+    }
+  }
+
+  const stigResults = await getEvaluationSummary(BoundaryId, undefined, false);
+
+  const stigArray = Array.isArray(stigResults) ? stigResults : [stigResults];
+  const controlToStatusMap = new Map<string, Map<string, Set<string>>>();
+  const stigLookup: { [vKey: string]: { cciIds: Set<string>; stig: any } } = {};
+
+  for (const stig of stigArray) {
+    for (const stigData of stig.StigData) {
+      for (const stigIdent of stigData.StigIdents) {
+        const vKey = stigData.vuln_num;
+        stigLookup[vKey] ??= { cciIds: new Set(), stig };
+        stigLookup[vKey].cciIds.add(stigIdent.text);
+      }
+      const status = stigData.status;
+      const vKey = stigData.vuln_num;
+      const title = stig.title || "";
+      const displayValue = title ? `${vKey} - ${title}` : vKey;
+
+      const cciIds = stigData.StigIdents.map((c: any) => c.text);
+
+      for (const cciId of cciIds) {
+        const cciItem = cciItemMap.get(cciId);
+        const cciRef = cciItem?.CciReferences?.[0]?.index ?? "";
+        const normalizedControl = parseTopLevelControl(cciRef);
+        if (!normalizedControl) continue;
+
+        if (!controlToStatusMap.has(normalizedControl)) {
+          controlToStatusMap.set(normalizedControl, new Map());
+        }
+
+        const statusMap = controlToStatusMap.get(normalizedControl)!;
+        if (!statusMap.has(status)) {
+          statusMap.set(status, new Set());
+        }
+        statusMap.get(status)!.add(displayValue);
+      }
+    }
+  }
+  perfTimer.stop("Query");
+  function parseTopLevelControl(raw: string) {
+    if (!raw) return "";
+    const cleaned = raw.toUpperCase().replace(/\s+/g, "");
+    const match = cleaned.match(/^([A-Z]{2,3}-\d+)(\(\d+\))?/);
+    if (!match) return cleaned;
+    return match[1] + (match[2] || "");
+  }
+  const controlSummaries: (ControlSummary | EnhancementSummary)[] = results.map((item) => {
+    if (item.ControlEnhancementId && item.ControlEnhancement) {
+      const normalizedControlNumber = parseTopLevelControl(
+        item.ControlEnhancement.enhancementIdentifier,
+      );
+      const statusMap = controlToStatusMap.get(normalizedControlNumber);
+      const cciIds = cciMap.get(normalizedControlNumber) || [];
+      let cci = "";
+      let technicalAssessmentComments;
+      let technicalAssessmentStatus = "";
+      if (statusMap && statusMap.size > 0) {
+        technicalAssessmentStatus = evaluateStatuses(statusMap);
+        const displayLines = buildDisplayLines(statusMap);
+
+        technicalAssessmentComments = displayLines;
+
+        for (const cciId of cciIds) {
+          const cciVKeys: { vKey: string; status: string }[] = [];
+          for (const [status, vKeys] of statusMap) {
+            for (const vKey of vKeys) {
+              const originalVKey = vKey.split(" - ")[0];
+              if (stigLookup[originalVKey] && stigLookup[originalVKey].cciIds.has(cciId)) {
+                cciVKeys.push({ vKey: originalVKey, status });
+              }
+            }
+          }
+          if (cciVKeys.length === 0) {
+            continue;
+          }
+          const cciStatus = determineCciStatus(cciVKeys);
+          cci += `  ${cciId}: ${cciStatus || "Not Reviewed"}\n`;
+        }
+      } else {
+        technicalAssessmentComments = ["No applicable STIG mapping for this Control."];
+      }
+      const result = getEnhancementSummary(
+        item,
+        cci,
+        technicalAssessmentStatus,
+        technicalAssessmentComments,
+      );
+      return result;
+    }
+    if (item.Control && item.Control.ControlNumber) {
+      const normalizedControlNumber = parseTopLevelControl(item.Control.ControlNumber.number);
+      const statusMap = controlToStatusMap.get(normalizedControlNumber);
+      const cciIds = cciMap.get(normalizedControlNumber) || [];
+      let cci = "";
+      let technicalAssessmentComments;
+      let technicalAssessmentStatus = "";
+      if (statusMap && statusMap.size > 0) {
+        technicalAssessmentStatus = evaluateStatuses(statusMap);
+        const displayLines = buildDisplayLines(statusMap);
+        technicalAssessmentComments = displayLines;
+
+        for (const cciId of cciIds) {
+          const cciVKeys: { vKey: string; status: string }[] = [];
+          for (const [status, vKeys] of statusMap) {
+            for (const vKey of vKeys) {
+              const originalVKey = vKey.split(" - ")[0];
+              if (stigLookup[originalVKey] && stigLookup[originalVKey].cciIds.has(cciId)) {
+                cciVKeys.push({ vKey: originalVKey, status });
+              }
+            }
+          }
+          if (cciVKeys.length === 0) {
+            continue;
+          }
+          const cciStatus = determineCciStatus(cciVKeys);
+          cci += `  ${cciId}: ${cciStatus || "Not Reviewed"}\n`;
+        }
+      } else {
+        technicalAssessmentComments = ["No applicable STIG mapping for this Control."];
+      }
+      const result = getStandardControlSummary(
+        item,
+        cci,
+        technicalAssessmentStatus,
+        technicalAssessmentComments,
+      );
+      return result;
+    }
     throw new Error("ControlRecordItem without Control or Enhancement");
   });
   return controlSummaries;

--- a/server/utils/controls.ts
+++ b/server/utils/controls.ts
@@ -419,6 +419,58 @@ function getTechnicalAssessment(
   };
 }
 
+function parseTopLevelControl(raw: string): string {
+  if (!raw) return "";
+
+  const cleaned = raw.toUpperCase().replace(/\s+/g, "");
+  const match = cleaned.match(/^([A-Z]{2,3}-\d+)(\(\d+\))?/);
+
+  return match
+    ? match[1] + (match[2] ?? "")
+    : cleaned;
+}
+
+async function loadCciItems(policyDocumentId: number | undefined) {
+  return CciItem.findAll({
+    attributes: ["cciId", "definition"],
+    include: [
+      {
+        model: CciReference,
+        attributes: ["index"],
+        through: { attributes: [] },
+        where: {
+          PolicyDocumentId: policyDocumentId,
+        },
+      },
+    ],
+  });
+}
+
+function buildCciMaps(cciItems: Awaited<ReturnType<typeof loadCciItems>>) {
+  const cciItemMap = new Map(
+    cciItems.map((item) => [item.cciId, item]),
+  );
+
+  const cciMap = new Map<string, string[]>();
+
+  for (const item of cciItems) {
+    for (const reference of item.CciReferences ?? []) {
+      if (!reference.index) continue;
+
+      const controlNumber = parseTopLevelControl(reference.index);
+      const mappedCcis = cciMap.get(controlNumber) ?? [];
+
+      mappedCcis.push(item.cciId);
+      cciMap.set(controlNumber, mappedCcis);
+    }
+  }
+
+  return {
+    cciItemMap,
+    cciMap,
+  };
+}
+
 export async function getControlSummary(
   BoundaryId: number,
   ControlRecordId: number,
@@ -484,33 +536,11 @@ export async function getControlSummary(
     ],
   });
 
-  const cciItems = await CciItem.findAll({
-    attributes: ["cciId", "definition"],
-    include: [
-      {
-        model: CciReference,
-        attributes: ["index"],
-        through: { attributes: [] },
-        where: {
-          PolicyDocumentId: boundary?.PolicyDocumentId,
-        },
-      },
-    ],
-  });
-  const cciItemMap = new Map(cciItems.map((item) => [item.cciId, item]));
-  const cciMap = new Map<string, string[]>();
+  const cciItems = await loadCciItems(
+    boundary?.PolicyDocumentId,
+  );
 
-  for (const cciItem of cciItems) {
-    const refs = cciItem.CciReferences ?? [];
-    for (const ref of refs) {
-      if (!ref.index) continue;
-      const normalizedIndex = parseTopLevelControl(ref.index);
-      if (!cciMap.has(normalizedIndex)) {
-        cciMap.set(normalizedIndex, []);
-      }
-      cciMap.get(normalizedIndex)!.push(cciItem.cciId);
-    }
-  }
+  const { cciItemMap, cciMap } = buildCciMaps(cciItems);
 
   const stigResults = await getEvaluationSummary(BoundaryId, undefined, false);
 
@@ -564,13 +594,6 @@ export async function getControlSummary(
     }
   }
   perfTimer.stop("Query");
-  function parseTopLevelControl(raw: string) {
-    if (!raw) return "";
-    const cleaned = raw.toUpperCase().replace(/\s+/g, "");
-    const match = cleaned.match(/^([A-Z]{2,3}-\d+)(\(\d+\))?/);
-    if (!match) return cleaned;
-    return match[1] + (match[2] || "");
-  }
   const controlSummaries: (ControlSummary | EnhancementSummary)[] =
     results.map((item) => {
       if (item.ControlEnhancementId && item.ControlEnhancement) {


### PR DESCRIPTION
<!--
Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
The title drives the release and docs/CHANGELOG.md via semantic-release, so it
matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
-->

## Summary

<!-- What this PR does and why, in a sentence or two. -->
Adds a Technical Assessment section to the SCTM view so users can review the CCIs associated with each control and the corresponding STIG checks and implementation statuses.

## Changes

<!-- Notable changes. For larger PRs, group them, e.g. Added / Changed / Fixed / Removed. -->
Added

- Added a Technical Assessment section to the SCTM control view.
- Displayed all CCIs mapped to each control.
- Displayed STIG checks mapped to the applicable CCIs.
- Included the current status of each mapped STIG check.

## Testing

<!-- How did you verify this change? -->

- Verified that base controls display their applicable CCIs.
- Verified that control enhancements continue to display their applicable CCIs.
- Verified that each STIG check displays its current status.
- Verified that controls without applicable STIG mappings are handled correctly.

## Related

<!-- closes #..., relates to #..., discussion or ADR links -->

<!--
Breaking change? Uncomment the line below and describe what breaks.
Leave this commented out if nothing breaks.

BREAKING CHANGE: what breaks and how to migrate
-->
