### PR TITLE
Fix/missing base control ccis 218

### DIFF
--- a/components/sctm/SecurityAssessment.vue
+++ b/components/sctm/SecurityAssessment.vue
@@ -54,7 +54,7 @@
             </span>
           </ListboxButton>
 
-          <transition
+          <Transition
             leave-active-class="transition ease-in duration-100"
             leave-from-class="opacity-100"
             leave-to-class="opacity-0"
@@ -93,7 +93,7 @@
                 </li>
               </ListboxOption>
             </ListboxOptions>
-          </transition>
+          </Transition>
         </div>
       </Listbox>
     </div>
@@ -180,7 +180,7 @@
             </span>
           </ListboxButton>
 
-          <transition
+          <Transition
             leave-active-class="transition ease-in duration-100"
             leave-from-class="opacity-100"
             leave-to-class="opacity-0"
@@ -219,7 +219,7 @@
                 </li>
               </ListboxOption>
             </ListboxOptions>
-          </transition>
+          </Transition>
         </div>
       </Listbox>
     </div>
@@ -255,7 +255,7 @@
 
 <script setup lang="ts">
 import { CheckIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
-import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions, Transition } from "@headlessui/vue";
+import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from "@headlessui/vue";
 
 interface DropdownItem {
   id: number;

--- a/server/utils/cciMapping.ts
+++ b/server/utils/cciMapping.ts
@@ -1,0 +1,58 @@
+import { CciItem, CciReference } from "~/db/models";
+
+export function normalizeCciControlIndex(index: string): string | null {
+  const controlMatch = index
+    .trim()
+    .toUpperCase()
+    .match(/^([A-Z]{2}-\s*\d+(?:\s*\(\d+\))?)/);
+
+  return controlMatch
+    ? controlMatch[1].replace(/\s+/g, "")
+    : null;
+}
+
+export async function getCciMappingData(
+  policyDocumentId: number | undefined,
+) {
+  const cciItems = await CciItem.findAll({
+    attributes: ["cciId", "definition"],
+    include: [
+      {
+        model: CciReference,
+        attributes: ["index"],
+        through: { attributes: [] },
+        where: {
+          PolicyDocumentId: policyDocumentId,
+        },
+      },
+    ],
+  });
+
+  const cciMap = new Map<string, string[]>();
+
+  for (const cciItem of cciItems) {
+    const refs = cciItem.CciReferences ?? [];
+
+    for (const ref of refs) {
+      if (!ref.index) continue;
+
+      const normalizedIndex =
+        normalizeCciControlIndex(ref.index);
+
+      if (!normalizedIndex) continue;
+
+      const cciIds = cciMap.get(normalizedIndex) ?? [];
+
+      if (!cciIds.includes(cciItem.cciId)) {
+        cciIds.push(cciItem.cciId);
+      }
+
+      cciMap.set(normalizedIndex, cciIds);
+    }
+  }
+
+  return {
+    cciItems,
+    cciMap,
+  };
+}

--- a/server/utils/excelExport/scaExport.ts
+++ b/server/utils/excelExport/scaExport.ts
@@ -16,10 +16,12 @@ import {
   FrequencyType,
   ImplementationStatus,
   TestMethod,
-  CciItem,
-  CciReference,
   ComplianceStatus,
 } from "~/db/models";
+import {
+  getCciMappingData,
+  normalizeCciControlIndex,
+} from "~/server/utils/cciMapping";
 
 export async function generateSecurityControlAssessment(
   boundaryId: number,
@@ -374,52 +376,13 @@ export async function generateSecurityControlAssessment(
     ],
   });
 
-  const cciItems = await CciItem.findAll({
-    attributes: ["cciId", "definition"],
-    include: [
-      {
-        model: CciReference,
-        attributes: ["index"],
-        through: { attributes: [] },
-        where: {
-          PolicyDocumentId: boundary?.PolicyDocumentId,
-        },
-      },
-    ],
-  });
+  const { cciItems, cciMap } = await getCciMappingData(
+    boundary?.PolicyDocumentId,
+  );
 
-  function normalizeCciControlIndex(index: string): string | null {
-    const controlMatch = index
-      .trim()
-      .toUpperCase()
-      .match(/^([A-Z]{2}-\s*\d+(?:\s*\(\d+\))?)/);
-
-    return controlMatch ? controlMatch[1].replace(/\s+/g, "") : null;
-  }
-
-  const cciItemMap = new Map(cciItems.map((item) => [item.cciId, item]));
-  const cciMap = new Map<string, string[]>();
-
-  for (const cciItem of cciItems) {
-    const refs = cciItem.CciReferences ?? [];
-    for (const ref of refs) {
-      if (!ref.index) continue;
-      // Roll statement references up to their base control or enhancement.
-
-      const normalizedIndex = normalizeCciControlIndex(ref.index);
-      if (!normalizedIndex) continue;
-
-      if (!cciMap.has(normalizedIndex)) {
-        cciMap.set(normalizedIndex, []);
-      }
-
-      const cciIds = cciMap.get(normalizedIndex)!;
-
-      if (!cciIds.includes(cciItem.cciId)) {
-        cciIds.push(cciItem.cciId);
-      }
-    }
-  }
+  const cciItemMap = new Map(
+    cciItems.map((item) => [item.cciId, item]),
+  );
 
   const stigResults = await getEvaluationSummary(boundaryId, undefined, false);
 
@@ -590,7 +553,7 @@ export async function generateSecurityControlAssessment(
     }
 
     newRow[Columns.controlNumber] = controlNumber;
-    const normalizedControlNumber = controlNumber.replace(/\s+/g, "").toUpperCase();
+    const normalizedControlNumber = normalizeCciControlIndex(controlNumber) ?? "";
     const statusMap = controlToStatusMap.get(normalizedControlNumber);
     const cciIds = cciMap.get(normalizedControlNumber) || [];
     newRow[Columns.cci] = cciIds.length ? cciIds.join("\n") + "\n" : "";

--- a/server/utils/excelExport/scaExport.ts
+++ b/server/utils/excelExport/scaExport.ts
@@ -387,6 +387,16 @@ export async function generateSecurityControlAssessment(
       },
     ],
   });
+
+  function normalizeCciControlIndex(index: string): string | null {
+    const controlMatch = index
+      .trim()
+      .toUpperCase()
+      .match(/^([A-Z]{2}-\s*\d+(?:\s*\(\d+\))?)/);
+
+    return controlMatch ? controlMatch[1].replace(/\s+/g, "") : null;
+  }
+
   const cciItemMap = new Map(cciItems.map((item) => [item.cciId, item]));
   const cciMap = new Map<string, string[]>();
 
@@ -395,14 +405,9 @@ export async function generateSecurityControlAssessment(
     for (const ref of refs) {
       if (!ref.index) continue;
       // Roll statement references up to their base control or enhancement.
-      const controlMatch = ref.index
-        .trim()
-        .toUpperCase()
-        .match(/^([A-Z]{2}-\d+(?:\s*\(\d+\))?)/);
 
-      if (!controlMatch) continue;
-
-      const normalizedIndex = controlMatch[1].replace(/\s+/g, "");
+      const normalizedIndex = normalizeCciControlIndex(ref.index);
+      if (!normalizedIndex) continue;
 
       if (!cciMap.has(normalizedIndex)) {
         cciMap.set(normalizedIndex, []);
@@ -432,19 +437,26 @@ export async function generateSecurityControlAssessment(
 
       for (const cciId of cciIds) {
         const cciItem = cciItemMap.get(cciId);
-        const cciRef = cciItem?.CciReferences?.[0]?.index ?? "";
-        const normalizedControl = cciRef.replace(/\s+/g, "");
-        if (!normalizedControl) continue;
+        const refs = cciItem?.CciReferences ?? [];
 
-        if (!controlToStatusMap.has(normalizedControl)) {
-          controlToStatusMap.set(normalizedControl, new Map());
-        }
+        for (const ref of refs) {
+          if (!ref.index) continue;
 
-        const statusMap = controlToStatusMap.get(normalizedControl)!;
-        if (!statusMap.has(status)) {
-          statusMap.set(status, new Set());
+          const normalizedControl = normalizeCciControlIndex(ref.index);
+          if (!normalizedControl) continue;
+
+          if (!controlToStatusMap.has(normalizedControl)) {
+            controlToStatusMap.set(normalizedControl, new Map());
+          }
+
+          const statusMap = controlToStatusMap.get(normalizedControl)!;
+
+          if (!statusMap.has(status)) {
+            statusMap.set(status, new Set());
+          }
+
+          statusMap.get(status)!.add(displayValue);
         }
-        statusMap.get(status)!.add(displayValue);
       }
     }
   }
@@ -578,9 +590,7 @@ export async function generateSecurityControlAssessment(
     }
 
     newRow[Columns.controlNumber] = controlNumber;
-    const normalizedControlNumber = controlNumber
-      .replace(/\s+/g, "")
-      .toUpperCase();
+    const normalizedControlNumber = controlNumber.replace(/\s+/g, "").toUpperCase();
     const statusMap = controlToStatusMap.get(normalizedControlNumber);
     const cciIds = cciMap.get(normalizedControlNumber) || [];
     newRow[Columns.cci] = cciIds.length ? cciIds.join("\n") + "\n" : "";

--- a/server/utils/excelExport/scaExport.ts
+++ b/server/utils/excelExport/scaExport.ts
@@ -394,11 +394,25 @@ export async function generateSecurityControlAssessment(
     const refs = cciItem.CciReferences ?? [];
     for (const ref of refs) {
       if (!ref.index) continue;
-      const normalizedIndex = ref.index.replace(/\s+/g, "");
+      // Roll statement references up to their base control or enhancement.
+      const controlMatch = ref.index
+        .trim()
+        .toUpperCase()
+        .match(/^([A-Z]{2}-\d+(?:\s*\(\d+\))?)/);
+
+      if (!controlMatch) continue;
+
+      const normalizedIndex = controlMatch[1].replace(/\s+/g, "");
+
       if (!cciMap.has(normalizedIndex)) {
         cciMap.set(normalizedIndex, []);
       }
-      cciMap.get(normalizedIndex)!.push(cciItem.cciId);
+
+      const cciIds = cciMap.get(normalizedIndex)!;
+
+      if (!cciIds.includes(cciItem.cciId)) {
+        cciIds.push(cciItem.cciId);
+      }
     }
   }
 
@@ -564,7 +578,9 @@ export async function generateSecurityControlAssessment(
     }
 
     newRow[Columns.controlNumber] = controlNumber;
-    const normalizedControlNumber = controlNumber.replace(/\s+/g, "");
+    const normalizedControlNumber = controlNumber
+      .replace(/\s+/g, "")
+      .toUpperCase();
     const statusMap = controlToStatusMap.get(normalizedControlNumber);
     const cciIds = cciMap.get(normalizedControlNumber) || [];
     newRow[Columns.cci] = cciIds.length ? cciIds.join("\n") + "\n" : "";

--- a/server/utils/excelExport/sctmExport.ts
+++ b/server/utils/excelExport/sctmExport.ts
@@ -398,12 +398,25 @@ export async function generateSctm(
       for (const ref of refs) {
         if (!ref.index) continue;
 
-        // Normalize by removing spaces for universal matching
-        const normalizedIndex = ref.index.replace(/\s+/g, "");
+        // Roll statement-level references up to their base control or enhancement
+        const controlMatch = ref.index
+          .trim()
+          .toUpperCase()
+          .match(/^([A-Z]{2}-\d+(?:\s*\(\d+\))?)/);
+
+        if (!controlMatch) continue;
+
+        const normalizedIndex = controlMatch[1].replace(/\s+/g, "");
+
         if (!cciMap.has(normalizedIndex)) {
           cciMap.set(normalizedIndex, []);
         }
-        cciMap.get(normalizedIndex)!.push(cciItem.cciId);
+
+        const cciIds = cciMap.get(normalizedIndex)!;
+
+        if (!cciIds.includes(cciItem.cciId)) {
+          cciIds.push(cciItem.cciId);
+        }
       }
     }
 
@@ -521,7 +534,9 @@ export async function generateSctm(
         control.ControlStatements?.map((s: any) => s.description).join("\n") || "";
     }
     newRow[Columns.controlNumber] = controlNumber;
-    const normalizedControlNumber = controlNumber.replace(/\s+/g, "");
+    const normalizedControlNumber = controlNumber
+      .replace(/\s+/g, "")
+      .toUpperCase();
     const cciIds = cciMap.get(normalizedControlNumber) || [];
     newRow[Columns.cci] = cciIds.length ? cciIds.join("\n") + "\n" : "";
     // Map all other fields from ControlRecordItem

--- a/server/utils/excelExport/sctmExport.ts
+++ b/server/utils/excelExport/sctmExport.ts
@@ -16,9 +16,11 @@ import {
   FrequencyType,
   ImplementationStatus,
   TestMethod,
-  CciItem,
-  CciReference
 } from "~/db/models";
+import {
+  getCciMappingData,
+  normalizeCciControlIndex,
+} from "~/server/utils/cciMapping";
 
 export async function generateSctm(
   boundaryId: number,
@@ -376,49 +378,9 @@ export async function generateSctm(
     ],
   }))
 
-  const cciItems = await CciItem.findAll({
-      attributes: ["cciId", "definition"],
-      include: [
-        {
-          model: CciReference,
-          attributes: ["index"],
-          through: { attributes: [] },
-          where: {
-            PolicyDocumentId: boundary?.PolicyDocumentId,
-          },
-        },
-      ],
-    });
-
-    const cciMap = new Map<string, string[]>();
-
-
-    for (const cciItem of cciItems) {
-      const refs = cciItem.CciReferences ?? []; // safe fallback
-      for (const ref of refs) {
-        if (!ref.index) continue;
-
-        // Roll statement-level references up to their base control or enhancement
-        const controlMatch = ref.index
-          .trim()
-          .toUpperCase()
-          .match(/^([A-Z]{2}-\d+(?:\s*\(\d+\))?)/);
-
-        if (!controlMatch) continue;
-
-        const normalizedIndex = controlMatch[1].replace(/\s+/g, "");
-
-        if (!cciMap.has(normalizedIndex)) {
-          cciMap.set(normalizedIndex, []);
-        }
-
-        const cciIds = cciMap.get(normalizedIndex)!;
-
-        if (!cciIds.includes(cciItem.cciId)) {
-          cciIds.push(cciItem.cciId);
-        }
-      }
-    }
+  const { cciMap } = await getCciMappingData(
+    boundary?.PolicyDocumentId,
+  );
 
   const revName = `rev${boundary?.PolicyDocument?.version}`;
   const revision = await ControlRevision.findOne({ where: { name: revName } });
@@ -534,9 +496,7 @@ export async function generateSctm(
         control.ControlStatements?.map((s: any) => s.description).join("\n") || "";
     }
     newRow[Columns.controlNumber] = controlNumber;
-    const normalizedControlNumber = controlNumber
-      .replace(/\s+/g, "")
-      .toUpperCase();
+    const normalizedControlNumber = normalizeCciControlIndex(controlNumber) ?? "";
     const cciIds = cciMap.get(normalizedControlNumber) || [];
     newRow[Columns.cci] = cciIds.length ? cciIds.join("\n") + "\n" : "";
     // Map all other fields from ControlRecordItem


### PR DESCRIPTION
<!--
Title: use Conventional Commits, e.g. feat(auth): add OAuth provider
The title drives the release and docs/CHANGELOG.md via semantic-release, so it
matters on squash merges. Types: feat, fix, docs, refactor, perf, test, build,
ci, chore, style. For a breaking change, add a "BREAKING CHANGE:" footer.
-->

## Summary

<!-- What this PR does and why, in a sentence or two. -->
Fixes missing CCI mappings in SCTM and SCA exports and ensures SCA technical assessment findings are associated with the correct controls.

DISA CCI references are often mapped to statement-level indexes such as SI-3 a or SI-3 c 1, while export rows use the base control identifier SI-3. The export logic now normalizes these references to their base control or enhancement before performing lookups.

## Changes

<!-- Notable changes. For larger PRs, group them, e.g. Added / Changed / Fixed / Removed. -->
Fixed
- Normalize statement-level CCI reference indexes to their base control or enhancement identifier.
- Map references such as SI-3 a and SI-3 c 1 to SI-3.
- Preserve enhancement mappings such as SI-2 (6) as SI-2(6).
- Include base-control CCIs in both SCTM and SCA exports.
- Prevent duplicate CCI entries when multiple references map to the same control.
- Apply the same normalization when rolling STIG findings into SCA technical assessment details.
- Process all references associated with each CCI instead of only the first reference.
- Ensure technical assessment comments and statuses match the applicable control rows.

## Testing

<!-- How did you verify this change? -->

- Generated SCTM and SCA exports and verified base controls now include their expected CCIs.
- Verified control enhancements continue to receive their expected CCIs.
- Generated an SCA export and confirmed applicable STIG findings appear under Technical Assessment Comments.
- Verified controls without applicable STIG findings continue to display the existing fallback message.
- Verified technical assessment fields remain blank for controls with an implementation status of Not Applicable.

## Related

<!-- closes #..., relates to #..., discussion or ADR links -->
Closes #218
Closes #217

<!--
Breaking change? Uncomment the line below and describe what breaks.
Leave this commented out if nothing breaks.

BREAKING CHANGE: what breaks and how to migrate
-->
